### PR TITLE
updated links to template and sample DCAT files with relative paths

### DIFF
--- a/metadata-resources.md
+++ b/metadata-resources.md
@@ -11,14 +11,14 @@ This section provides further background and resources to assist agencies in imp
 
 <table width="60%">
 <b><tr><td><ul>
-<li><a href="https://raw.github.com/project-open-data/project-open-data.github.io/gh-pages/examples/catalog-template.json">JSON</a></li>
-<li><a href="https://raw.github.com/project-open-data/project-open-data.github.io/gh-pages/examples/catalog-template.html">RDFa Lite</a></li>
-<li><a href="https://raw.github.com/project-open-data/project-open-data.github.io/gh-pages/examples/catalog-template.csv">CSV</a></li>
+<li><a href="/examples/catalog-template.json">JSON</a></li>
+<li><a href="/examples/catalog-template.html">RDFa Lite</a></li>
+<li><a href="/examples/catalog-template.csv">CSV</a></li>
 </ul></td>
 <td><ul>
-<li><a href="https://raw.github.com/project-open-data/project-open-data.github.io/gh-pages/examples/catalog-template-extended.json">JSON (Extended)</a></li>
-<li><a href="https://raw.github.com/project-open-data/project-open-data.github.io/gh-pages/examples/catalog-template-extended.html">RDFa Lite (Extended)</a></li>
-<li><a href="https://raw.github.com/project-open-data/project-open-data.github.io/gh-pages/examples/catalog-template-extended.csv">CSV (Extended)</a></li>
+<li><a href="/examples/catalog-template-extended.json">JSON (Extended)</a></li>
+<li><a href="/examples/catalog-template-extended.html">RDFa Lite (Extended)</a></li>
+<li><a href="/examples/catalog-template-extended.csv">CSV (Extended)</a></li>
 </ul></td></tr></b>
 </table>
 
@@ -26,14 +26,14 @@ This section provides further background and resources to assist agencies in imp
 
 <table width="60%">
 <b><tr><td><ul>
-<li><a href="https://raw.github.com/project-open-data/project-open-data.github.io/gh-pages/examples/catalog-sample.json">JSON</a></li>
-<li><a href="https://raw.github.com/project-open-data/project-open-data.github.io/gh-pages/examples/catalog-sample.html">RDFa Lite</a></li>
-<li><a href="https://raw.github.com/project-open-data/project-open-data.github.io/gh-pages/examples/catalog-sample.csv">CSV</a></li>
+<li><a href="/examples/catalog-sample.json">JSON</a></li>
+<li><a href="/examples/catalog-sample.html">RDFa Lite</a></li>
+<li><a href="/examples/catalog-sample.csv">CSV</a></li>
 </ul></td>
 <td><ul>
-<li><a href="https://raw.github.com/project-open-data/project-open-data.github.io/gh-pages/examples/catalog-sample-extended.json">JSON (Extended)</a></li>
-<li><a href="https://raw.github.com/project-open-data/project-open-data.github.io/gh-pages/examples/catalog-sample-extended.html">RDFa Lite (Extended)</a></li>
-<li><a href="https://raw.github.com/project-open-data/project-open-data.github.io/gh-pages/examples/catalog-sample-extended.csv">CSV (Extended)</a></li>
+<li><a href="/examples/catalog-sample-extended.json">JSON (Extended)</a></li>
+<li><a href="/examples/catalog-sample-extended.html">RDFa Lite (Extended)</a></li>
+<li><a href="/examples/catalog-sample-extended.csv">CSV (Extended)</a></li>
 </ul></td></tr></b>
 </table>
 


### PR DESCRIPTION
The absolute references to the templates and samples were broken. replaced these by relative paths to the master branch.
