### PR TITLE
Use Prose.io for editing, rather than the the project's fork

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ branch: master
 #global settings, no need to change these
 root_url: http://project-open-data.github.io
 org_name: project-open-data
-prose_url: http://project-open-data.github.io/contribute/
+prose_url: http://prose.io
 
 # default build settings for running locally, no need to edit
 pymgemnts: true


### PR DESCRIPTION
Project open data launched using http://project-open-data.github.io/contribute for editing due to two upstream issues (https://github.com/prose/prose/issues/403, and https://github.com/prose/prose/issues/389). 

Now that Prose v1.0 is out, rather than maintain our own fork, it would make sense to have the :pencil: button point_right: directly to http://prose.io.

Prose.io hosts prose v1, which is a complete overhaul and includes:

> - Complete user interface redesign
> - Metadata editor for Jekyll post front matter
> - In-layout previews for Jekyll posts
> - Support for multilingual content
> - Many bug fixes and performance improvements
> - [See the v1.0.0 milestone for the full list](https://github.com/prose/prose/issues?milestone=12&page=1&state=closed)

I believe it to be significantly more user friendly (:computer:), and as a free service (:moneybag:), requires no action or upkeep on our part (:wrench:). Prose would require the user to :key: with their :octocat: account (as they do now with our fork), but all subsequent requests will be directly to from the user's browser to the GitHub API, minimizing the risk of any information or activity being exposed to or altered by third-parties.

This pull request simply changes the variable in the config file from our fork to http://prose.io and should require no further action on our part once merged.
