### PR TITLE
Suggested edits to further conform to ISO 8601 temporal standards

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -253,9 +253,9 @@ Field       | title
 ----- | -----
 **Cardinality** | (0,1)
 **Required** | No
-**Accepted Values** | Must be one of the following: hourly, daily, weekly, yearly, other
+**Accepted Values** | Must be one of the following: Annual, Bimonthly, Semiweekly, Daily, Biweekly, Semiannual, Biennial, Triennial, Three times a week, Three times a month, Continuously updated, Monthly, Quarterly, Semimonthly, Three times a year, Weekly, Completely irregular
 **Usage Notes** | -
-**Example** |  `{"accrualPeriodicity":"yearly"}`
+**Example** |  `{"accrualPeriodicity":"annual"}`
 
 {.table .table-striped}
 **Field** | **language**


### PR DESCRIPTION
It looks like this has been brought up before in (https://github.com/project-open-data/project-open-data.github.io/pull/43) but a solid commit was not made to align fully with the ISO 8601 standard. I suggest expressing datetimes as `YYYY-MM-DDTHH:MM:SSZ` and ranges as `YYYY-MM-DDTHH:MM:SSZ/YYYY-MM-DDTHH:MM:SSZ`.
