### PR TITLE
Use RDFa Lite 1.1 property attribute

### DIFF
--- a/examples/catalog-sample-extended.html
+++ b/examples/catalog-sample-extended.html
@@ -5,137 +5,137 @@
       
       <li>
         <strong>Title:</strong> 
-        <span rel="dct:title">Office Locations</span>
+        <span property="dct:title">Office Locations</span>
       </li>
       
       <li>
         <strong>Description:</strong> 
-        <span rel="dct:description">A list of the agency's office locations and contact information.</span>
+        <span property="dct:description">A list of the agency's office locations and contact information.</span>
       </li>
       
       <li>
         <strong>Documentation URL:</strong> 
-        <span rel="dcat:dataDictionary">http://www.agency.gov/data/information/locations</span>
+        <span property="dcat:dataDictionary">http://www.agency.gov/data/information/locations</span>
       </li>
       
       <li>
         <strong>Download URL:</strong> 
-        <span rel="dcat:download">http://www.agency.gov/data/raw/locations.zip</span>
+        <span property="dcat:download">http://www.agency.gov/data/raw/locations.zip</span>
       </li>
       
       <li>
         <strong>Format:</strong> 
-        <span rel="dcterms:format">csv</span>
+        <span property="dcterms:format">csv</span>
       </li>
       
       <li>
         <strong>Tags:</strong> 
-        <span rel="dcat:keyword">keyword1</span>
+        <span property="dcat:keyword">keyword1</span>
       </li>
       
       <li>
         <strong>Last Update:</strong> 
-        <span rel="dcterms:modified">1/1/2013</span>
+        <span property="dcterms:modified">1/1/2013</span>
       </li>
       
       <li>
         <strong>Publisher:</strong> 
-        <span rel="foaf:Organization">Agency</span>
+        <span property="foaf:Organization">Agency</span>
       </li>
       
       <li>
         <strong>Contact Name:</strong> 
-        <span rel="foaf:Person">John, Smith</span>
+        <span property="foaf:Person">John, Smith</span>
       </li>
       
       <li>
         <strong>Contact Email:</strong> 
-        <span rel="foaf:mbox">john.smith@agency.gov</span>
+        <span property="foaf:mbox">john.smith@agency.gov</span>
       </li>
       
       <li>
         <strong>Unique Identifier:</strong> 
-        <span rel="dcterms:identifier">1</span>
+        <span property="dcterms:identifier">1</span>
       </li>
       
       <li>
         <strong>Public:</strong> 
-        <span rel="xsd:boolean">true</span>
+        <span property="xsd:boolean">true</span>
       </li>
       
       <li>
         <strong>Endpoint:</strong> 
-        <span rel="dcat:webService">http://www.agency.gov/data/raw/locations.json</span>
+        <span property="dcat:webService">http://www.agency.gov/data/raw/locations.json</span>
       </li>
       
       <li>
         <strong>License:</strong> 
-        <span rel="dcterms:license">public domain</span>
+        <span property="dcterms:license">public domain</span>
       </li>
       
       <li>
         <strong>Spatial:</strong> 
-        <span rel="dcterms:spatial">United States</span>
+        <span property="dcterms:spatial">United States</span>
       </li>
       
       <li>
         <strong>Temporal:</strong> 
-        <span rel="dcterms:temporal">today</span>
+        <span property="dcterms:temporal">today</span>
       </li>
       
       <li>
         <strong>Release Date:</strong> 
-        <span rel="dct:issued">7/9/2012</span>
+        <span property="dct:issued">7/9/2012</span>
       </li>
       
       <li>
         <strong>Frequency:</strong> 
-        <span rel="dct:accrualPeriodocity">6 months</span>
+        <span property="dct:accrualPeriodocity">6 months</span>
       </li>
       
       <li>
         <strong>Language:</strong> 
-        <span rel="dcat:language">English</span>
+        <span property="dcat:language">English</span>
       </li>
       
       <li>
         <strong>Granularity:</strong> 
-        <span rel="dcat:granularity">Address</span>
+        <span property="dcat:granularity">Address</span>
       </li>
       
       <li>
         <strong>Category:</strong> 
-        <span rel="dcat:theme">Energy</span>
+        <span property="dcat:theme">Energy</span>
       </li>
       
       <li>
         <strong>Related Documents:</strong> 
-        <span rel="dcat:distribution">http://www.agency.gov/data/information/locations/document.doc</span>
+        <span property="dcat:distribution">http://www.agency.gov/data/information/locations/document.doc</span>
       </li>
       
       <li>
         <strong>Distribution:</strong> 
-        <span rel="dcat:distribution"></span>
+        <span property="dcat:distribution"></span>
       </li>
       
       <li>
         <strong>Size:</strong> 
-        <span rel="dcat:size">44KB</span>
+        <span property="dcat:size">44KB</span>
       </li>
       
       <li>
         <strong>Homepage URL:</strong> 
-        <span rel="foaf:homepage"></span>
+        <span property="foaf:homepage"></span>
       </li>
       
       <li>
         <strong>RSS Feed:</strong> 
-        <span rel="dcat:feed"></span>
+        <span property="dcat:feed"></span>
       </li>
       
       <li>
         <strong>Data Quality:</strong> 
-        <span rel="dcat:dataQuality">True</span>
+        <span property="dcat:dataQuality">True</span>
       </li>
       
     </ul>
@@ -146,137 +146,137 @@
       
       <li>
         <strong>Title:</strong> 
-        <span rel="dct:title">Database Export</span>
+        <span property="dct:title">Database Export</span>
       </li>
       
       <li>
         <strong>Description:</strong> 
-        <span rel="dct:description">A full export of the agency's database.</span>
+        <span property="dct:description">A full export of the agency's database.</span>
       </li>
       
       <li>
         <strong>Documentation URL:</strong> 
-        <span rel="dcat:dataDictionary">http://www.agency.gov/data/information/database</span>
+        <span property="dcat:dataDictionary">http://www.agency.gov/data/information/database</span>
       </li>
       
       <li>
         <strong>Download URL:</strong> 
-        <span rel="dcat:download">http://www.agency.gov/data/raw/database.csv</span>
+        <span property="dcat:download">http://www.agency.gov/data/raw/database.csv</span>
       </li>
       
       <li>
         <strong>Format:</strong> 
-        <span rel="dcterms:format">xml</span>
+        <span property="dcterms:format">xml</span>
       </li>
       
       <li>
         <strong>Tags:</strong> 
-        <span rel="dcat:keyword">keyword2</span>
+        <span property="dcat:keyword">keyword2</span>
       </li>
       
       <li>
         <strong>Last Update:</strong> 
-        <span rel="dcterms:modified">2/1/2013</span>
+        <span property="dcterms:modified">2/1/2013</span>
       </li>
       
       <li>
         <strong>Publisher:</strong> 
-        <span rel="foaf:Organization">Agency</span>
+        <span property="foaf:Organization">Agency</span>
       </li>
       
       <li>
         <strong>Contact Name:</strong> 
-        <span rel="foaf:Person">Jane, Smith</span>
+        <span property="foaf:Person">Jane, Smith</span>
       </li>
       
       <li>
         <strong>Contact Email:</strong> 
-        <span rel="foaf:mbox">jane.smith@agency.gov</span>
+        <span property="foaf:mbox">jane.smith@agency.gov</span>
       </li>
       
       <li>
         <strong>Unique Identifier:</strong> 
-        <span rel="dcterms:identifier">2</span>
+        <span property="dcterms:identifier">2</span>
       </li>
       
       <li>
         <strong>Public:</strong> 
-        <span rel="xsd:boolean">true</span>
+        <span property="xsd:boolean">true</span>
       </li>
       
       <li>
         <strong>Endpoint:</strong> 
-        <span rel="dcat:webService"></span>
+        <span property="dcat:webService"></span>
       </li>
       
       <li>
         <strong>License:</strong> 
-        <span rel="dcterms:license">public domain</span>
+        <span property="dcterms:license">public domain</span>
       </li>
       
       <li>
         <strong>Spatial:</strong> 
-        <span rel="dcterms:spatial">United States</span>
+        <span property="dcterms:spatial">United States</span>
       </li>
       
       <li>
         <strong>Temporal:</strong> 
-        <span rel="dcterms:temporal">2001-current</span>
+        <span property="dcterms:temporal">2001-current</span>
       </li>
       
       <li>
         <strong>Release Date:</strong> 
-        <span rel="dct:issued">3/1/2012</span>
+        <span property="dct:issued">3/1/2012</span>
       </li>
       
       <li>
         <strong>Frequency:</strong> 
-        <span rel="dct:accrualPeriodocity">yearly</span>
+        <span property="dct:accrualPeriodocity">yearly</span>
       </li>
       
       <li>
         <strong>Language:</strong> 
-        <span rel="dcat:language">English</span>
+        <span property="dcat:language">English</span>
       </li>
       
       <li>
         <strong>Granularity:</strong> 
-        <span rel="dcat:granularity">Station</span>
+        <span property="dcat:granularity">Station</span>
       </li>
       
       <li>
         <strong>Category:</strong> 
-        <span rel="dcat:theme">Education</span>
+        <span property="dcat:theme">Education</span>
       </li>
       
       <li>
         <strong>Related Documents:</strong> 
-        <span rel="dcat:distribution">http://www.agency.gov/bureau1/document3.doc, http://www.agency.gov/bureau1/document5.txt</span>
+        <span property="dcat:distribution">http://www.agency.gov/bureau1/document3.doc, http://www.agency.gov/bureau1/document5.txt</span>
       </li>
       
       <li>
         <strong>Distribution:</strong> 
-        <span rel="dcat:distribution"></span>
+        <span property="dcat:distribution"></span>
       </li>
       
       <li>
         <strong>Size:</strong> 
-        <span rel="dcat:size">5MB</span>
+        <span property="dcat:size">5MB</span>
       </li>
       
       <li>
         <strong>Homepage URL:</strong> 
-        <span rel="foaf:homepage">http://www.agency.gov/data/information/database</span>
+        <span property="foaf:homepage">http://www.agency.gov/data/information/database</span>
       </li>
       
       <li>
         <strong>RSS Feed:</strong> 
-        <span rel="dcat:feed">http://www.agency.gov/data/raw/database.rss</span>
+        <span property="dcat:feed">http://www.agency.gov/data/raw/database.rss</span>
       </li>
       
       <li>
         <strong>Data Quality:</strong> 
-        <span rel="dcat:dataQuality">True</span>
+        <span property="dcat:dataQuality">True</span>
       </li>
       
     </ul>
@@ -287,137 +287,137 @@
       
       <li>
         <strong>Title:</strong> 
-        <span rel="dct:title">System Data API</span>
+        <span property="dct:title">System Data API</span>
       </li>
       
       <li>
         <strong>Description:</strong> 
-        <span rel="dct:description">A restful web service for a system's data set from 2012.</span>
+        <span property="dct:description">A restful web service for a system's data set from 2012.</span>
       </li>
       
       <li>
         <strong>Documentation URL:</strong> 
-        <span rel="dcat:dataDictionary">http://www.agency.gov/data/information/system_api</span>
+        <span property="dcat:dataDictionary">http://www.agency.gov/data/information/system_api</span>
       </li>
       
       <li>
         <strong>Download URL:</strong> 
-        <span rel="dcat:download">http://www.agency.gov/data/raw/system_2012.csv</span>
+        <span property="dcat:download">http://www.agency.gov/data/raw/system_2012.csv</span>
       </li>
       
       <li>
         <strong>Format:</strong> 
-        <span rel="dcterms:format">csv, json</span>
+        <span property="dcterms:format">csv, json</span>
       </li>
       
       <li>
         <strong>Tags:</strong> 
-        <span rel="dcat:keyword">keyword1, keyword2</span>
+        <span property="dcat:keyword">keyword1, keyword2</span>
       </li>
       
       <li>
         <strong>Last Update:</strong> 
-        <span rel="dcterms:modified">12/15/2012</span>
+        <span property="dcterms:modified">12/15/2012</span>
       </li>
       
       <li>
         <strong>Publisher:</strong> 
-        <span rel="foaf:Organization">Agency</span>
+        <span property="foaf:Organization">Agency</span>
       </li>
       
       <li>
         <strong>Contact Name:</strong> 
-        <span rel="foaf:Person">Bill, Smith</span>
+        <span property="foaf:Person">Bill, Smith</span>
       </li>
       
       <li>
         <strong>Contact Email:</strong> 
-        <span rel="foaf:mbox">bill.smith@agency.gov</span>
+        <span property="foaf:mbox">bill.smith@agency.gov</span>
       </li>
       
       <li>
         <strong>Unique Identifier:</strong> 
-        <span rel="dcterms:identifier">3</span>
+        <span property="dcterms:identifier">3</span>
       </li>
       
       <li>
         <strong>Public:</strong> 
-        <span rel="xsd:boolean">true</span>
+        <span property="xsd:boolean">true</span>
       </li>
       
       <li>
         <strong>Endpoint:</strong> 
-        <span rel="dcat:webService">http://www.agency.gov/data/raw/data_api.json</span>
+        <span property="dcat:webService">http://www.agency.gov/data/raw/data_api.json</span>
       </li>
       
       <li>
         <strong>License:</strong> 
-        <span rel="dcterms:license">creative commons Cco</span>
+        <span property="dcterms:license">creative commons Cco</span>
       </li>
       
       <li>
         <strong>Spatial:</strong> 
-        <span rel="dcterms:spatial">United States</span>
+        <span property="dcterms:spatial">United States</span>
       </li>
       
       <li>
         <strong>Temporal:</strong> 
-        <span rel="dcterms:temporal">2012</span>
+        <span property="dcterms:temporal">2012</span>
       </li>
       
       <li>
         <strong>Release Date:</strong> 
-        <span rel="dct:issued">2/15/2013</span>
+        <span property="dct:issued">2/15/2013</span>
       </li>
       
       <li>
         <strong>Frequency:</strong> 
-        <span rel="dct:accrualPeriodocity">weekly</span>
+        <span property="dct:accrualPeriodocity">weekly</span>
       </li>
       
       <li>
         <strong>Language:</strong> 
-        <span rel="dcat:language">English</span>
+        <span property="dcat:language">English</span>
       </li>
       
       <li>
         <strong>Granularity:</strong> 
-        <span rel="dcat:granularity">Individual</span>
+        <span property="dcat:granularity">Individual</span>
       </li>
       
       <li>
         <strong>Category:</strong> 
-        <span rel="dcat:theme">Health, Education</span>
+        <span property="dcat:theme">Health, Education</span>
       </li>
       
       <li>
         <strong>Related Documents:</strong> 
-        <span rel="dcat:distribution">http://www.agency.gov/bureau1/document3.pdf</span>
+        <span property="dcat:distribution">http://www.agency.gov/bureau1/document3.pdf</span>
       </li>
       
       <li>
         <strong>Distribution:</strong> 
-        <span rel="dcat:distribution"></span>
+        <span property="dcat:distribution"></span>
       </li>
       
       <li>
         <strong>Size:</strong> 
-        <span rel="dcat:size">300MB</span>
+        <span property="dcat:size">300MB</span>
       </li>
       
       <li>
         <strong>Homepage URL:</strong> 
-        <span rel="foaf:homepage"></span>
+        <span property="foaf:homepage"></span>
       </li>
       
       <li>
         <strong>RSS Feed:</strong> 
-        <span rel="dcat:feed"></span>
+        <span property="dcat:feed"></span>
       </li>
       
       <li>
         <strong>Data Quality:</strong> 
-        <span rel="dcat:dataQuality">True</span>
+        <span property="dcat:dataQuality">True</span>
       </li>
       
     </ul>

--- a/examples/catalog-sample-extended.xml
+++ b/examples/catalog-sample-extended.xml
@@ -1,173 +1,173 @@
 <datasets>
   <dataset id="1">
     
-      <attribute rel="dct:title">Office Locations</attribute>
+      <attribute property="dct:title">Office Locations</attribute>
       
-      <attribute rel="dct:description">A list of the agency's office locations and contact information.</attribute>
+      <attribute property="dct:description">A list of the agency's office locations and contact information.</attribute>
       
-      <attribute rel="dcat:dataDictionary">http://www.agency.gov/data/information/locations</attribute>
+      <attribute property="dcat:dataDictionary">http://www.agency.gov/data/information/locations</attribute>
       
-      <attribute rel="dcat:download">http://www.agency.gov/data/raw/locations.zip</attribute>
+      <attribute property="dcat:download">http://www.agency.gov/data/raw/locations.zip</attribute>
       
-      <attribute rel="dcterms:format">csv</attribute>
+      <attribute property="dcterms:format">csv</attribute>
       
-      <attribute rel="dcat:keyword">keyword1</attribute>
+      <attribute property="dcat:keyword">keyword1</attribute>
       
-      <attribute rel="dcterms:modified">1/1/2013</attribute>
+      <attribute property="dcterms:modified">1/1/2013</attribute>
       
-      <attribute rel="foaf:Organization">Agency</attribute>
+      <attribute property="foaf:Organization">Agency</attribute>
       
-      <attribute rel="foaf:Person">John, Smith</attribute>
+      <attribute property="foaf:Person">John, Smith</attribute>
       
-      <attribute rel="foaf:mbox">john.smith@agency.gov</attribute>
+      <attribute property="foaf:mbox">john.smith@agency.gov</attribute>
       
-      <attribute rel="dcterms:identifier">1</attribute>
+      <attribute property="dcterms:identifier">1</attribute>
       
-      <attribute rel="xsd:boolean">true</attribute>
+      <attribute property="xsd:boolean">true</attribute>
       
-      <attribute rel="dcat:webService">http://www.agency.gov/data/raw/locations.json</attribute>
+      <attribute property="dcat:webService">http://www.agency.gov/data/raw/locations.json</attribute>
       
-      <attribute rel="dcterms:license">public domain</attribute>
+      <attribute property="dcterms:license">public domain</attribute>
       
-      <attribute rel="dcterms:spatial">United States</attribute>
+      <attribute property="dcterms:spatial">United States</attribute>
       
-      <attribute rel="dcterms:temporal">today</attribute>
+      <attribute property="dcterms:temporal">today</attribute>
       
-      <attribute rel="dct:issued">7/9/2012</attribute>
+      <attribute property="dct:issued">7/9/2012</attribute>
       
-      <attribute rel="dct:accrualPeriodocity">6 months</attribute>
+      <attribute property="dct:accrualPeriodocity">6 months</attribute>
       
-      <attribute rel="dcat:language">English</attribute>
+      <attribute property="dcat:language">English</attribute>
       
-      <attribute rel="dcat:granularity">Address</attribute>
+      <attribute property="dcat:granularity">Address</attribute>
       
-      <attribute rel="dcat:theme">Energy</attribute>
+      <attribute property="dcat:theme">Energy</attribute>
       
-      <attribute rel="dcat:distribution">http://www.agency.gov/data/information/locations/document.doc</attribute>
+      <attribute property="dcat:distribution">http://www.agency.gov/data/information/locations/document.doc</attribute>
       
-      <attribute rel="dcat:distribution"></attribute>
+      <attribute property="dcat:distribution"></attribute>
       
-      <attribute rel="dcat:size">44KB</attribute>
+      <attribute property="dcat:size">44KB</attribute>
       
-      <attribute rel="foaf:homepage"></attribute>
+      <attribute property="foaf:homepage"></attribute>
       
-      <attribute rel="dcat:feed"></attribute>
+      <attribute property="dcat:feed"></attribute>
       
-      <attribute rel="dcat:dataQuality">True</attribute>
+      <attribute property="dcat:dataQuality">True</attribute>
       
   </dataset>
   <dataset id="2">
     
-      <attribute rel="dct:title">Database Export</attribute>
+      <attribute property="dct:title">Database Export</attribute>
       
-      <attribute rel="dct:description">A full export of the agency's database.</attribute>
+      <attribute property="dct:description">A full export of the agency's database.</attribute>
       
-      <attribute rel="dcat:dataDictionary">http://www.agency.gov/data/information/database</attribute>
+      <attribute property="dcat:dataDictionary">http://www.agency.gov/data/information/database</attribute>
       
-      <attribute rel="dcat:download">http://www.agency.gov/data/raw/database.csv</attribute>
+      <attribute property="dcat:download">http://www.agency.gov/data/raw/database.csv</attribute>
       
-      <attribute rel="dcterms:format">xml</attribute>
+      <attribute property="dcterms:format">xml</attribute>
       
-      <attribute rel="dcat:keyword">keyword2</attribute>
+      <attribute property="dcat:keyword">keyword2</attribute>
       
-      <attribute rel="dcterms:modified">2/1/2013</attribute>
+      <attribute property="dcterms:modified">2/1/2013</attribute>
       
-      <attribute rel="foaf:Organization">Agency</attribute>
+      <attribute property="foaf:Organization">Agency</attribute>
       
-      <attribute rel="foaf:Person">Jane, Smith</attribute>
+      <attribute property="foaf:Person">Jane, Smith</attribute>
       
-      <attribute rel="foaf:mbox">jane.smith@agency.gov</attribute>
+      <attribute property="foaf:mbox">jane.smith@agency.gov</attribute>
       
-      <attribute rel="dcterms:identifier">2</attribute>
+      <attribute property="dcterms:identifier">2</attribute>
       
-      <attribute rel="xsd:boolean">true</attribute>
+      <attribute property="xsd:boolean">true</attribute>
       
-      <attribute rel="dcat:webService"></attribute>
+      <attribute property="dcat:webService"></attribute>
       
-      <attribute rel="dcterms:license">public domain</attribute>
+      <attribute property="dcterms:license">public domain</attribute>
       
-      <attribute rel="dcterms:spatial">United States</attribute>
+      <attribute property="dcterms:spatial">United States</attribute>
       
-      <attribute rel="dcterms:temporal">2001-current</attribute>
+      <attribute property="dcterms:temporal">2001-current</attribute>
       
-      <attribute rel="dct:issued">3/1/2012</attribute>
+      <attribute property="dct:issued">3/1/2012</attribute>
       
-      <attribute rel="dct:accrualPeriodocity">yearly</attribute>
+      <attribute property="dct:accrualPeriodocity">yearly</attribute>
       
-      <attribute rel="dcat:language">English</attribute>
+      <attribute property="dcat:language">English</attribute>
       
-      <attribute rel="dcat:granularity">Station</attribute>
+      <attribute property="dcat:granularity">Station</attribute>
       
-      <attribute rel="dcat:theme">Education</attribute>
+      <attribute property="dcat:theme">Education</attribute>
       
-      <attribute rel="dcat:distribution">http://www.agency.gov/bureau1/document3.doc, http://www.agency.gov/bureau1/document5.txt</attribute>
+      <attribute property="dcat:distribution">http://www.agency.gov/bureau1/document3.doc, http://www.agency.gov/bureau1/document5.txt</attribute>
       
-      <attribute rel="dcat:distribution"></attribute>
+      <attribute property="dcat:distribution"></attribute>
       
-      <attribute rel="dcat:size">5MB</attribute>
+      <attribute property="dcat:size">5MB</attribute>
       
-      <attribute rel="foaf:homepage">http://www.agency.gov/data/information/database</attribute>
+      <attribute property="foaf:homepage">http://www.agency.gov/data/information/database</attribute>
       
-      <attribute rel="dcat:feed">http://www.agency.gov/data/raw/database.rss</attribute>
+      <attribute property="dcat:feed">http://www.agency.gov/data/raw/database.rss</attribute>
       
-      <attribute rel="dcat:dataQuality">True</attribute>
+      <attribute property="dcat:dataQuality">True</attribute>
       
   </dataset>
   <dataset id="3">
     
-      <attribute rel="dct:title">System Data API</attribute>
+      <attribute property="dct:title">System Data API</attribute>
       
-      <attribute rel="dct:description">A restful web service for a system's data set from 2012.</attribute>
+      <attribute property="dct:description">A restful web service for a system's data set from 2012.</attribute>
       
-      <attribute rel="dcat:dataDictionary">http://www.agency.gov/data/information/system_api</attribute>
+      <attribute property="dcat:dataDictionary">http://www.agency.gov/data/information/system_api</attribute>
       
-      <attribute rel="dcat:download">http://www.agency.gov/data/raw/system_2012.csv</attribute>
+      <attribute property="dcat:download">http://www.agency.gov/data/raw/system_2012.csv</attribute>
       
-      <attribute rel="dcterms:format">csv, json</attribute>
+      <attribute property="dcterms:format">csv, json</attribute>
       
-      <attribute rel="dcat:keyword">keyword1, keyword2</attribute>
+      <attribute property="dcat:keyword">keyword1, keyword2</attribute>
       
-      <attribute rel="dcterms:modified">12/15/2012</attribute>
+      <attribute property="dcterms:modified">12/15/2012</attribute>
       
-      <attribute rel="foaf:Organization">Agency</attribute>
+      <attribute property="foaf:Organization">Agency</attribute>
       
-      <attribute rel="foaf:Person">Bill, Smith</attribute>
+      <attribute property="foaf:Person">Bill, Smith</attribute>
       
-      <attribute rel="foaf:mbox">bill.smith@agency.gov</attribute>
+      <attribute property="foaf:mbox">bill.smith@agency.gov</attribute>
       
-      <attribute rel="dcterms:identifier">3</attribute>
+      <attribute property="dcterms:identifier">3</attribute>
       
-      <attribute rel="xsd:boolean">true</attribute>
+      <attribute property="xsd:boolean">true</attribute>
       
-      <attribute rel="dcat:webService">http://www.agency.gov/data/raw/data_api.json</attribute>
+      <attribute property="dcat:webService">http://www.agency.gov/data/raw/data_api.json</attribute>
       
-      <attribute rel="dcterms:license">creative commons Cco</attribute>
+      <attribute property="dcterms:license">creative commons Cco</attribute>
       
-      <attribute rel="dcterms:spatial">United States</attribute>
+      <attribute property="dcterms:spatial">United States</attribute>
       
-      <attribute rel="dcterms:temporal">2012</attribute>
+      <attribute property="dcterms:temporal">2012</attribute>
       
-      <attribute rel="dct:issued">2/15/2013</attribute>
+      <attribute property="dct:issued">2/15/2013</attribute>
       
-      <attribute rel="dct:accrualPeriodocity">weekly</attribute>
+      <attribute property="dct:accrualPeriodocity">weekly</attribute>
       
-      <attribute rel="dcat:language">English</attribute>
+      <attribute property="dcat:language">English</attribute>
       
-      <attribute rel="dcat:granularity">Individual</attribute>
+      <attribute property="dcat:granularity">Individual</attribute>
       
-      <attribute rel="dcat:theme">Health, Education</attribute>
+      <attribute property="dcat:theme">Health, Education</attribute>
       
-      <attribute rel="dcat:distribution">http://www.agency.gov/bureau1/document3.pdf</attribute>
+      <attribute property="dcat:distribution">http://www.agency.gov/bureau1/document3.pdf</attribute>
       
-      <attribute rel="dcat:distribution"></attribute>
+      <attribute property="dcat:distribution"></attribute>
       
-      <attribute rel="dcat:size">300MB</attribute>
+      <attribute property="dcat:size">300MB</attribute>
       
-      <attribute rel="foaf:homepage"></attribute>
+      <attribute property="foaf:homepage"></attribute>
       
-      <attribute rel="dcat:feed"></attribute>
+      <attribute property="dcat:feed"></attribute>
       
-      <attribute rel="dcat:dataQuality">True</attribute>
+      <attribute property="dcat:dataQuality">True</attribute>
       
   </dataset>
 </datasets>

--- a/examples/catalog-sample.html
+++ b/examples/catalog-sample.html
@@ -5,82 +5,82 @@
       
       <li>
         <strong>Title:</strong> 
-        <span rel="dct:title">Office Locations</span>
+        <span property="dct:title">Office Locations</span>
       </li>
       
       <li>
         <strong>Description:</strong> 
-        <span rel="dct:description">A list of the agency's office locations and contact information.</span>
+        <span property="dct:description">A list of the agency's office locations and contact information.</span>
       </li>
       
       <li>
         <strong>Documentation URL:</strong> 
-        <span rel="dcat:dataDictionary">http://www.agency.gov/data/information/locations</span>
+        <span property="dcat:dataDictionary">http://www.agency.gov/data/information/locations</span>
       </li>
       
       <li>
         <strong>Download URL:</strong> 
-        <span rel="dcat:download">http://www.agency.gov/data/raw/locations.zip</span>
+        <span property="dcat:download">http://www.agency.gov/data/raw/locations.zip</span>
       </li>
       
       <li>
         <strong>Format:</strong> 
-        <span rel="dcterms:format">csv</span>
+        <span property="dcterms:format">csv</span>
       </li>
       
       <li>
         <strong>Tags:</strong> 
-        <span rel="dcat:keyword">keyword1</span>
+        <span property="dcat:keyword">keyword1</span>
       </li>
       
       <li>
         <strong>Last Update:</strong> 
-        <span rel="dcterms:modified">1/1/2013</span>
+        <span property="dcterms:modified">1/1/2013</span>
       </li>
       
       <li>
         <strong>Publisher:</strong> 
-        <span rel="foaf:Organization">Agency</span>
+        <span property="foaf:Organization">Agency</span>
       </li>
       
       <li>
         <strong>Contact Name:</strong> 
-        <span rel="foaf:Person">John, Smith</span>
+        <span property="foaf:Person">John, Smith</span>
       </li>
       
       <li>
         <strong>Contact Email:</strong> 
-        <span rel="foaf:mbox">john.smith@agency.gov</span>
+        <span property="foaf:mbox">john.smith@agency.gov</span>
       </li>
       
       <li>
         <strong>Unique Identifier:</strong> 
-        <span rel="dcterms:identifier">1</span>
+        <span property="dcterms:identifier">1</span>
       </li>
       
       <li>
         <strong>Public:</strong> 
-        <span rel="xsd:boolean">true</span>
+        <span property="xsd:boolean">true</span>
       </li>
       
       <li>
         <strong>Endpoint:</strong> 
-        <span rel="dcat:webService">http://www.agency.gov/data/raw/locations.json</span>
+        <span property="dcat:webService">http://www.agency.gov/data/raw/locations.json</span>
       </li>
       
       <li>
         <strong>License:</strong> 
-        <span rel="dcterms:license">public domain</span>
+        <span property="dcterms:license">public domain</span>
       </li>
       
       <li>
         <strong>Spatial:</strong> 
-        <span rel="dcterms:spatial">United States</span>
+        <span property="dcterms:spatial">United States</span>
       </li>
       
       <li>
         <strong>Temporal:</strong> 
-        <span rel="dcterms:temporal">today</span>
+        <span property="dcterms:temporal">today</span>
       </li>
       
     </ul>
@@ -91,82 +91,82 @@
       
       <li>
         <strong>Title:</strong> 
-        <span rel="dct:title">Database Export</span>
+        <span property="dct:title">Database Export</span>
       </li>
       
       <li>
         <strong>Description:</strong> 
-        <span rel="dct:description">A full export of the agency's database.</span>
+        <span property="dct:description">A full export of the agency's database.</span>
       </li>
       
       <li>
         <strong>Documentation URL:</strong> 
-        <span rel="dcat:dataDictionary">http://www.agency.gov/data/information/database</span>
+        <span property="dcat:dataDictionary">http://www.agency.gov/data/information/database</span>
       </li>
       
       <li>
         <strong>Download URL:</strong> 
-        <span rel="dcat:download">http://www.agency.gov/data/raw/database.csv</span>
+        <span property="dcat:download">http://www.agency.gov/data/raw/database.csv</span>
       </li>
       
       <li>
         <strong>Format:</strong> 
-        <span rel="dcterms:format">xml</span>
+        <span property="dcterms:format">xml</span>
       </li>
       
       <li>
         <strong>Tags:</strong> 
-        <span rel="dcat:keyword">keyword2</span>
+        <span property="dcat:keyword">keyword2</span>
       </li>
       
       <li>
         <strong>Last Update:</strong> 
-        <span rel="dcterms:modified">2/1/2013</span>
+        <span property="dcterms:modified">2/1/2013</span>
       </li>
       
       <li>
         <strong>Publisher:</strong> 
-        <span rel="foaf:Organization">Agency</span>
+        <span property="foaf:Organization">Agency</span>
       </li>
       
       <li>
         <strong>Contact Name:</strong> 
-        <span rel="foaf:Person">Jane, Smith</span>
+        <span property="foaf:Person">Jane, Smith</span>
       </li>
       
       <li>
         <strong>Contact Email:</strong> 
-        <span rel="foaf:mbox">jane.smith@agency.gov</span>
+        <span property="foaf:mbox">jane.smith@agency.gov</span>
       </li>
       
       <li>
         <strong>Unique Identifier:</strong> 
-        <span rel="dcterms:identifier">2</span>
+        <span property="dcterms:identifier">2</span>
       </li>
       
       <li>
         <strong>Public:</strong> 
-        <span rel="xsd:boolean">true</span>
+        <span property="xsd:boolean">true</span>
       </li>
       
       <li>
         <strong>Endpoint:</strong> 
-        <span rel="dcat:webService"></span>
+        <span property="dcat:webService"></span>
       </li>
       
       <li>
         <strong>License:</strong> 
-        <span rel="dcterms:license">public domain</span>
+        <span property="dcterms:license">public domain</span>
       </li>
       
       <li>
         <strong>Spatial:</strong> 
-        <span rel="dcterms:spatial">United States</span>
+        <span property="dcterms:spatial">United States</span>
       </li>
       
       <li>
         <strong>Temporal:</strong> 
-        <span rel="dcterms:temporal">2001-current</span>
+        <span property="dcterms:temporal">2001-current</span>
       </li>
       
     </ul>
@@ -177,82 +177,82 @@
       
       <li>
         <strong>Title:</strong> 
-        <span rel="dct:title">System Data API</span>
+        <span property="dct:title">System Data API</span>
       </li>
       
       <li>
         <strong>Description:</strong> 
-        <span rel="dct:description">A restful web service for a system's data set from 2012.</span>
+        <span property="dct:description">A restful web service for a system's data set from 2012.</span>
       </li>
       
       <li>
         <strong>Documentation URL:</strong> 
-        <span rel="dcat:dataDictionary">http://www.agency.gov/data/information/system_api</span>
+        <span property="dcat:dataDictionary">http://www.agency.gov/data/information/system_api</span>
       </li>
       
       <li>
         <strong>Download URL:</strong> 
-        <span rel="dcat:download">http://www.agency.gov/data/raw/system_2012.csv</span>
+        <span property="dcat:download">http://www.agency.gov/data/raw/system_2012.csv</span>
       </li>
       
       <li>
         <strong>Format:</strong> 
-        <span rel="dcterms:format">csv, json</span>
+        <span property="dcterms:format">csv, json</span>
       </li>
       
       <li>
         <strong>Tags:</strong> 
-        <span rel="dcat:keyword">keyword1, keyword2</span>
+        <span property="dcat:keyword">keyword1, keyword2</span>
       </li>
       
       <li>
         <strong>Last Update:</strong> 
-        <span rel="dcterms:modified">12/15/2012</span>
+        <span property="dcterms:modified">12/15/2012</span>
       </li>
       
       <li>
         <strong>Publisher:</strong> 
-        <span rel="foaf:Organization">Agency</span>
+        <span property="foaf:Organization">Agency</span>
       </li>
       
       <li>
         <strong>Contact Name:</strong> 
-        <span rel="foaf:Person">Bill, Smith</span>
+        <span property="foaf:Person">Bill, Smith</span>
       </li>
       
       <li>
         <strong>Contact Email:</strong> 
-        <span rel="foaf:mbox">bill.smith@agency.gov</span>
+        <span property="foaf:mbox">bill.smith@agency.gov</span>
       </li>
       
       <li>
         <strong>Unique Identifier:</strong> 
-        <span rel="dcterms:identifier">3</span>
+        <span property="dcterms:identifier">3</span>
       </li>
       
       <li>
         <strong>Public:</strong> 
-        <span rel="xsd:boolean">true</span>
+        <span property="xsd:boolean">true</span>
       </li>
       
       <li>
         <strong>Endpoint:</strong> 
-        <span rel="dcat:webService">http://www.agency.gov/data/raw/data_api.json</span>
+        <span property="dcat:webService">http://www.agency.gov/data/raw/data_api.json</span>
       </li>
       
       <li>
         <strong>License:</strong> 
-        <span rel="dcterms:license">creative commons Cco</span>
+        <span property="dcterms:license">creative commons Cco</span>
       </li>
       
       <li>
         <strong>Spatial:</strong> 
-        <span rel="dcterms:spatial">United States</span>
+        <span property="dcterms:spatial">United States</span>
       </li>
       
       <li>
         <strong>Temporal:</strong> 
-        <span rel="dcterms:temporal">2012</span>
+        <span property="dcterms:temporal">2012</span>
       </li>
       
     </ul>

--- a/examples/catalog-sample.xml
+++ b/examples/catalog-sample.xml
@@ -1,107 +1,107 @@
 <datasets>
   <dataset id="1">
     
-      <attribute rel="dct:title">Office Locations</attribute>
+      <attribute property="dct:title">Office Locations</attribute>
       
-      <attribute rel="dct:description">A list of the agency's office locations and contact information.</attribute>
+      <attribute property="dct:description">A list of the agency's office locations and contact information.</attribute>
       
-      <attribute rel="dcat:dataDictionary">http://www.agency.gov/data/information/locations</attribute>
+      <attribute property="dcat:dataDictionary">http://www.agency.gov/data/information/locations</attribute>
       
-      <attribute rel="dcat:download">http://www.agency.gov/data/raw/locations.zip</attribute>
+      <attribute property="dcat:download">http://www.agency.gov/data/raw/locations.zip</attribute>
       
-      <attribute rel="dcterms:format">csv</attribute>
+      <attribute property="dcterms:format">csv</attribute>
       
-      <attribute rel="dcat:keyword">keyword1</attribute>
+      <attribute property="dcat:keyword">keyword1</attribute>
       
-      <attribute rel="dcterms:modified">1/1/2013</attribute>
+      <attribute property="dcterms:modified">1/1/2013</attribute>
       
-      <attribute rel="foaf:Organization">Agency</attribute>
+      <attribute property="foaf:Organization">Agency</attribute>
       
-      <attribute rel="foaf:Person">John, Smith</attribute>
+      <attribute property="foaf:Person">John, Smith</attribute>
       
-      <attribute rel="foaf:mbox">john.smith@agency.gov</attribute>
+      <attribute property="foaf:mbox">john.smith@agency.gov</attribute>
       
-      <attribute rel="dcterms:identifier">1</attribute>
+      <attribute property="dcterms:identifier">1</attribute>
       
-      <attribute rel="xsd:boolean">true</attribute>
+      <attribute property="xsd:boolean">true</attribute>
       
-      <attribute rel="dcat:webService">http://www.agency.gov/data/raw/locations.json</attribute>
+      <attribute property="dcat:webService">http://www.agency.gov/data/raw/locations.json</attribute>
       
-      <attribute rel="dcterms:license">public domain</attribute>
+      <attribute property="dcterms:license">public domain</attribute>
       
-      <attribute rel="dcterms:spatial">United States</attribute>
+      <attribute property="dcterms:spatial">United States</attribute>
       
-      <attribute rel="dcterms:temporal">today</attribute>
+      <attribute property="dcterms:temporal">today</attribute>
       
   </dataset>
   <dataset id="2">
     
-      <attribute rel="dct:title">Database Export</attribute>
+      <attribute property="dct:title">Database Export</attribute>
       
-      <attribute rel="dct:description">A full export of the agency's database.</attribute>
+      <attribute property="dct:description">A full export of the agency's database.</attribute>
       
-      <attribute rel="dcat:dataDictionary">http://www.agency.gov/data/information/database</attribute>
+      <attribute property="dcat:dataDictionary">http://www.agency.gov/data/information/database</attribute>
       
-      <attribute rel="dcat:download">http://www.agency.gov/data/raw/database.csv</attribute>
+      <attribute property="dcat:download">http://www.agency.gov/data/raw/database.csv</attribute>
       
-      <attribute rel="dcterms:format">xml</attribute>
+      <attribute property="dcterms:format">xml</attribute>
       
-      <attribute rel="dcat:keyword">keyword2</attribute>
+      <attribute property="dcat:keyword">keyword2</attribute>
       
-      <attribute rel="dcterms:modified">2/1/2013</attribute>
+      <attribute property="dcterms:modified">2/1/2013</attribute>
       
-      <attribute rel="foaf:Organization">Agency</attribute>
+      <attribute property="foaf:Organization">Agency</attribute>
       
-      <attribute rel="foaf:Person">Jane, Smith</attribute>
+      <attribute property="foaf:Person">Jane, Smith</attribute>
       
-      <attribute rel="foaf:mbox">jane.smith@agency.gov</attribute>
+      <attribute property="foaf:mbox">jane.smith@agency.gov</attribute>
       
-      <attribute rel="dcterms:identifier">2</attribute>
+      <attribute property="dcterms:identifier">2</attribute>
       
-      <attribute rel="xsd:boolean">true</attribute>
+      <attribute property="xsd:boolean">true</attribute>
       
-      <attribute rel="dcat:webService"></attribute>
+      <attribute property="dcat:webService"></attribute>
       
-      <attribute rel="dcterms:license">public domain</attribute>
+      <attribute property="dcterms:license">public domain</attribute>
       
-      <attribute rel="dcterms:spatial">United States</attribute>
+      <attribute property="dcterms:spatial">United States</attribute>
       
-      <attribute rel="dcterms:temporal">2001-current</attribute>
+      <attribute property="dcterms:temporal">2001-current</attribute>
       
   </dataset>
   <dataset id="3">
     
-      <attribute rel="dct:title">System Data API</attribute>
+      <attribute property="dct:title">System Data API</attribute>
       
-      <attribute rel="dct:description">A restful web service for a system's data set from 2012.</attribute>
+      <attribute property="dct:description">A restful web service for a system's data set from 2012.</attribute>
       
-      <attribute rel="dcat:dataDictionary">http://www.agency.gov/data/information/system_api</attribute>
+      <attribute property="dcat:dataDictionary">http://www.agency.gov/data/information/system_api</attribute>
       
-      <attribute rel="dcat:download">http://www.agency.gov/data/raw/system_2012.csv</attribute>
+      <attribute property="dcat:download">http://www.agency.gov/data/raw/system_2012.csv</attribute>
       
-      <attribute rel="dcterms:format">csv, json</attribute>
+      <attribute property="dcterms:format">csv, json</attribute>
       
-      <attribute rel="dcat:keyword">keyword1, keyword2</attribute>
+      <attribute property="dcat:keyword">keyword1, keyword2</attribute>
       
-      <attribute rel="dcterms:modified">12/15/2012</attribute>
+      <attribute property="dcterms:modified">12/15/2012</attribute>
       
-      <attribute rel="foaf:Organization">Agency</attribute>
+      <attribute property="foaf:Organization">Agency</attribute>
       
-      <attribute rel="foaf:Person">Bill, Smith</attribute>
+      <attribute property="foaf:Person">Bill, Smith</attribute>
       
-      <attribute rel="foaf:mbox">bill.smith@agency.gov</attribute>
+      <attribute property="foaf:mbox">bill.smith@agency.gov</attribute>
       
-      <attribute rel="dcterms:identifier">3</attribute>
+      <attribute property="dcterms:identifier">3</attribute>
       
-      <attribute rel="xsd:boolean">true</attribute>
+      <attribute property="xsd:boolean">true</attribute>
       
-      <attribute rel="dcat:webService">http://www.agency.gov/data/raw/data_api.json</attribute>
+      <attribute property="dcat:webService">http://www.agency.gov/data/raw/data_api.json</attribute>
       
-      <attribute rel="dcterms:license">creative commons Cco</attribute>
+      <attribute property="dcterms:license">creative commons Cco</attribute>
       
-      <attribute rel="dcterms:spatial">United States</attribute>
+      <attribute property="dcterms:spatial">United States</attribute>
       
-      <attribute rel="dcterms:temporal">2012</attribute>
+      <attribute property="dcterms:temporal">2012</attribute>
       
   </dataset>
 </datasets>

--- a/examples/catalog-template.html
+++ b/examples/catalog-template.html
@@ -5,62 +5,62 @@
       
       <li>
         <strong>Title:</strong> 
-        <span rel="dct:title"></span>
+        <span property="dct:title"></span>
       </li>
       
       <li>
         <strong>Description:</strong> 
-        <span rel="dct:description"></span>
+        <span property="dct:description"></span>
       </li>
       
       <li>
         <strong>Documentation URL:</strong> 
-        <span rel="dcat:dataDictionary"></span>
+        <span property="dcat:dataDictionary"></span>
       </li>
       
       <li>
         <strong>Download URL:</strong> 
-        <span rel="dcat:download"></span>
+        <span property="dcat:download"></span>
       </li>
       
       <li>
         <strong>Format:</strong> 
-        <span rel="dcterms:format"></span>
+        <span property="dcterms:format"></span>
       </li>
       
       <li>
         <strong>Tags:</strong> 
-        <span rel="dcat:keyword"></span>
+        <span property="dcat:keyword"></span>
       </li>
       
       <li>
         <strong>Last Update:</strong> 
-        <span rel="dcterms:modified"></span>
+        <span property="dcterms:modified"></span>
       </li>
       
       <li>
         <strong>Publisher:</strong> 
-        <span rel="foaf:Organization"></span>
+        <span property="foaf:Organization"></span>
       </li>
       
       <li>
         <strong>Contact Name:</strong> 
-        <span rel="foaf:Person"></span>
+        <span property="foaf:Person"></span>
       </li>
       
       <li>
         <strong>Contact Email:</strong> 
-        <span rel="foaf:mbox"></span>
+        <span property="foaf:mbox"></span>
       </li>
       
       <li>
         <strong>Unique Identifier:</strong> 
-        <span rel="dcterms:identifier"></span>
+        <span property="dcterms:identifier"></span>
       </li>
       
       <li>
         <strong>Public:</strong> 
-        <span rel="xsd:boolean"></span>
+        <span property="xsd:boolean"></span>
       </li>
       
     </ul>
@@ -71,62 +71,62 @@
       
       <li>
         <strong>Title:</strong> 
-        <span rel="dct:title"></span>
+        <span property="dct:title"></span>
       </li>
       
       <li>
         <strong>Description:</strong> 
-        <span rel="dct:description"></span>
+        <span property="dct:description"></span>
       </li>
       
       <li>
         <strong>Documentation URL:</strong> 
-        <span rel="dcat:dataDictionary"></span>
+        <span property="dcat:dataDictionary"></span>
       </li>
       
       <li>
         <strong>Download URL:</strong> 
-        <span rel="dcat:download"></span>
+        <span property="dcat:download"></span>
       </li>
       
       <li>
         <strong>Format:</strong> 
-        <span rel="dcterms:format"></span>
+        <span property="dcterms:format"></span>
       </li>
       
       <li>
         <strong>Tags:</strong> 
-        <span rel="dcat:keyword"></span>
+        <span property="dcat:keyword"></span>
       </li>
       
       <li>
         <strong>Last Update:</strong> 
-        <span rel="dcterms:modified"></span>
+        <span property="dcterms:modified"></span>
       </li>
       
       <li>
         <strong>Publisher:</strong> 
-        <span rel="foaf:Organization"></span>
+        <span property="foaf:Organization"></span>
       </li>
       
       <li>
         <strong>Contact Name:</strong> 
-        <span rel="foaf:Person"></span>
+        <span property="foaf:Person"></span>
       </li>
       
       <li>
         <strong>Contact Email:</strong> 
-        <span rel="foaf:mbox"></span>
+        <span property="foaf:mbox"></span>
       </li>
       
       <li>
         <strong>Unique Identifier:</strong> 
-        <span rel="dcterms:identifier"></span>
+        <span property="dcterms:identifier"></span>
       </li>
       
       <li>
         <strong>Public:</strong> 
-        <span rel="xsd:boolean"></span>
+        <span property="xsd:boolean"></span>
       </li>
       
     </ul>

--- a/examples/catalog-template.xml
+++ b/examples/catalog-template.xml
@@ -1,56 +1,56 @@
 <datasets>
   <dataset id="">
     
-      <attribute rel="dct:title"></attribute>
+      <attribute property="dct:title"></attribute>
       
-      <attribute rel="dct:description"></attribute>
+      <attribute property="dct:description"></attribute>
       
-      <attribute rel="dcat:dataDictionary"></attribute>
+      <attribute property="dcat:dataDictionary"></attribute>
       
-      <attribute rel="dcat:download"></attribute>
+      <attribute property="dcat:download"></attribute>
       
-      <attribute rel="dcterms:format"></attribute>
+      <attribute property="dcterms:format"></attribute>
       
-      <attribute rel="dcat:keyword"></attribute>
+      <attribute property="dcat:keyword"></attribute>
       
-      <attribute rel="dcterms:modified"></attribute>
+      <attribute property="dcterms:modified"></attribute>
       
-      <attribute rel="foaf:Organization"></attribute>
+      <attribute property="foaf:Organization"></attribute>
       
-      <attribute rel="foaf:Person"></attribute>
+      <attribute property="foaf:Person"></attribute>
       
-      <attribute rel="foaf:mbox"></attribute>
+      <attribute property="foaf:mbox"></attribute>
       
-      <attribute rel="dcterms:identifier"></attribute>
+      <attribute property="dcterms:identifier"></attribute>
       
-      <attribute rel="xsd:boolean"></attribute>
+      <attribute property="xsd:boolean"></attribute>
       
   </dataset>
   <dataset id="">
     
-      <attribute rel="dct:title"></attribute>
+      <attribute property="dct:title"></attribute>
       
-      <attribute rel="dct:description"></attribute>
+      <attribute property="dct:description"></attribute>
       
-      <attribute rel="dcat:dataDictionary"></attribute>
+      <attribute property="dcat:dataDictionary"></attribute>
       
-      <attribute rel="dcat:download"></attribute>
+      <attribute property="dcat:download"></attribute>
       
-      <attribute rel="dcterms:format"></attribute>
+      <attribute property="dcterms:format"></attribute>
       
-      <attribute rel="dcat:keyword"></attribute>
+      <attribute property="dcat:keyword"></attribute>
       
-      <attribute rel="dcterms:modified"></attribute>
+      <attribute property="dcterms:modified"></attribute>
       
-      <attribute rel="foaf:Organization"></attribute>
+      <attribute property="foaf:Organization"></attribute>
       
-      <attribute rel="foaf:Person"></attribute>
+      <attribute property="foaf:Person"></attribute>
       
-      <attribute rel="foaf:mbox"></attribute>
+      <attribute property="foaf:mbox"></attribute>
       
-      <attribute rel="dcterms:identifier"></attribute>
+      <attribute property="dcterms:identifier"></attribute>
       
-      <attribute rel="xsd:boolean"></attribute>
+      <attribute property="xsd:boolean"></attribute>
       
   </dataset>
 </datasets>


### PR DESCRIPTION
The 'property' attribute should be used to annotate the content of each item of the templates, instead of 'rel' which has a different purpose.

http://www.w3.org/TR/rdfa-lite/
