### PR TITLE
Changing publisher cardinality to allow multiple values

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -161,11 +161,11 @@ Field       | title
 {.table .table-striped}
 **Field** | **publisher**
 ----- | -----
-**Cardinality** | (1,1)
+**Cardinality** | (1,n)
 **Required** | Yes, always
 **Accepted Values** | String
-**Usage Notes** | Departments and multi-unit agencies may use this field to describe which subordinate agency published this dataset.
-**Example** |  `{"publisher":"U.S. Department of Education"}`
+**Usage Notes** | Departments and multi-unit agencies may use this field to describe which subordinate agency published this dataset. If multiple agencies contributed, or if subordinate agencies need to be includes, a comma separated list may be used. 
+**Example** |  `{"publisher":"U.S. Department of Education"}` `{"publisher":"Department of Health and Human Services,Food and Drug Administration,Department of Agriculture"}`
 
 {.table .table-striped}
 **Field** | **person**


### PR DESCRIPTION
It would be useful to change the **publisher** field to allow for multiple agency contributions. This would be useful for datasets that are a result of joint agency collaboration (e.g. many NASA/NOAA datasets) or datasets that are from child agencies (such as HHS/FDA, Commerce/NOAA, etc) where there would be a benefit from listing both agencies as publishers.

Multiple publishers can simply be listed as comma delineated. This may also relate to https://github.com/project-open-data/project-open-data.github.io/issues/89
