### PR TITLE
Updated license field to contain additional information

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -217,9 +217,9 @@ Field       | title
 ----- | -----
 **Cardinality** | (0,1)
 **Required** | No
-**Accepted Values** | -
-**Usage Notes** | See list of licenses.
-**Example** |  `{"license":""}`
+**Accepted Values** | URL
+**Usage Notes** | See list of licenses. This field should contain a URL to the  license document. 
+**Example** |  `{"license":"http://opendatacommons.org/licenses/pddl/1.0/"}`
 
 {.table .table-striped}
 **Field** | **spatial**


### PR DESCRIPTION
The license field was lacking in detail on acceptable content. To make this simple, what if it just is a URL to the license document? This could also be some sort of dictionary with a title and URL, but I'm not sure if there is much additional value gained from that.
