### PR TITLE
Changed language field to adhere to RFC 5646

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -263,7 +263,7 @@ Field       | title
 **Cardinality** | (0,n)
 **Required** | No
 **Accepted Values** | String
-**Usage Notes** | This should adhere to the [RFC 5646](http://tools.ietf.org/html/rfc5646) standard. http://rishida.net/utils/subtags/ provides a good tool for checking and verifying language codes. A language tag is comprised of either one or two parts, the language subtag (such as en for English, sp for Spanish, wo for Wolof) and the regional subtag (such as US for United States, GB for Great Britain, MX for Mexico), separated by a hyphen. Regional subtags should only be provided when needed to distinguish a language tag for another one (such as American vs. British English).
+**Usage Notes** | This should adhere to the [RFC 5646](http://tools.ietf.org/html/rfc5646) standard. http://rishida.net/utils/subtags/ provides a good tool for checking and verifying language codes. A language tag is comprised of either one or two parts, the language subtag (such as en for English, sp for Spanish, wo for Wolof) and the regional subtag (such as US for United States, GB for Great Britain, MX for Mexico), separated by a hyphen. Regional subtags should only be provided when needed to distinguish a language tag from another one (such as American vs. British English).
 **Example** |  `{"language":"en-US"}` `{"language":"en-GB"}` `{"language":"jp"}` `{"language":"es-MX, wo, nv, en-US"}` 
 
 {.table .table-striped}


### PR DESCRIPTION
As mentioned in http://dublincore.org/documents/dcmi-terms/#terms-language, language fields should adhere to a controlled vocabulary such as [RFC 5646](http://tools.ietf.org/html/rfc5646). I've updated the schema to reflect that. I'm assuming documents in multiple languages should just be comma separated, though if I missed a place where the standard defines a better way to do that please edit accordingly.
