### PR TITLE
added Geoportal Server, an open source catalog

### DIFF
--- a/index.md
+++ b/index.md
@@ -76,6 +76,8 @@ This section is a list of ready-to-use solutions or tools that will help agencie
 
 4-10 [ckanext-datajson](https://github.com/HHS/ckanext-datajson) - A CKAN extension to generate agency.gov/data.json catalog files.
 
+4-10 [Esri Geoportal Server](https://github.com/Esri/geoportal-server/) - Open source catalog supporting ISO/FGDC/DC/... metadata with mapping to DCAT to support agency.gov/data.json listings in addition to providing [OGC CSW](http://www.opengeospatial.org/standards/cat), [OAI-PMH](http://www.openarchives.org/pmh/) and [OpenSearch](http://www.opensearch.org). Supports automated harvesting from other open catalog sources.
+
 ----------------
 
 ##5. Resources


### PR DESCRIPTION
Geoportal Server is an open source catalog licensed under Apache 2.0 that supports OpenSearch, OAI-PMH, CSW, DCAT, GeoRSS, ATOM as response formats to searches. Also supports harvesting a wide variety of sources and support federated searching to those sources.
