### PR TITLE
Use GitHub Pages Gem, rather than versioning Jekyll directly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,3 @@
 source "https://rubygems.org"
 
-# for latest versions, see:
-# https://help.github.com/articles/using-jekyll-with-pages#troubleshooting
-
-gem "jekyll",     '=1.1.2'
-gem 'liquid',     '=2.5.1'
-gem 'redcarpet',  '=2.2.2'
-gem 'maruku',     '=0.6.1'
-gem 'rdiscount',  '=1.6.8'
-gem 'RedCloth',   '=4.2.9'
+gem "github-pages"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,10 +5,18 @@ GEM
     classifier (1.3.3)
       fast-stemmer (>= 1.0.0)
     colorator (0.1)
-    commander (4.1.4)
+    commander (4.1.5)
       highline (~> 1.6.11)
     directory_watcher (1.4.1)
     fast-stemmer (1.0.2)
+    github-pages (1)
+      RedCloth (= 4.2.9)
+      jekyll (= 1.1.2)
+      kramdown (= 1.0.2)
+      liquid (= 2.5.1)
+      maruku (= 0.6.1)
+      rdiscount (= 1.6.8)
+      redcarpet (= 2.2.2)
     highline (1.6.19)
     jekyll (1.1.2)
       classifier (~> 1.3)
@@ -39,9 +47,4 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  RedCloth (= 4.2.9)
-  jekyll (= 1.1.2)
-  liquid (= 2.5.1)
-  maruku (= 0.6.1)
-  rdiscount (= 1.6.8)
-  redcarpet (= 2.2.2)
+  github-pages


### PR DESCRIPTION
Background: https://github.com/blog/1581-cutting-the-github-pages-gem

Use the newly released `github-pages` Gem to automagically keep local build environments in sync with the GitHub Pages build environment. This change will not affect the output in any way.

By using the GitHub Pages Gem, rather than manually bumping the Jekyll version we run, the version will always mirror production, ensuring that what you see locally, most closely matches what you see once published.
