### PR TITLE
Rename keyword field to "keywords"

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -141,13 +141,13 @@ Field       | title
 **Example** | `{"format":"csv"}`
 
 {.table .table-striped}
-**Field** | **keyword**
+**Field** | **keywords**
 ----- | -----
 **Cardinality** | (1,n)
 **Required** | Yes, always
 **Accepted Values** | String
 **Usage Notes** | Separate keywords with commas.
-**Example** | `{"keyword":"squash,vegetables,veggies,greens,leafy,spinach,kale,nutrition,tomatoes,tomatos"}`
+**Example** | `{"keywords":"squash,vegetables,veggies,greens,leafy,spinach,kale,nutrition,tomatoes,tomatos"}`
 
 {.table .table-striped}
 **Field** | **modified**


### PR DESCRIPTION
If the keyword field has multiple keywords, it would make more sense to call it "keywords". I as a developer would expect keyword to contain a single value, while even without reading docs, would expect keyword**s** to be an array.

Updated the schema here, but give me a shout out if I missed any other references and will gladly update the pull request.

//cc #33
