### PR TITLE
:fire: the size field

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -86,7 +86,6 @@ Granularity         | Level of granularity of the dataset.                      
 Data Quality        | Whether the dataset meets the agency's Information Quality Guidelines (true/false).                                                                                                             | dataQuality          
 Category            | Main thematic category of the dataset.                                                                                                        | theme                 
 Related Documents   | Related documents such as technical information about a dataset, developer documentation, etc.                                                                                            | references            
-Size                | The size of the downloadable dataset.                                                                                                         | size                  
 Homepage URL        | Alternative landing page used to redirect user to a contextual, Agency-hosted "homepage" for the Dataset or API when selecting this resource from the Data.gov user interface. | landingPage	            
 RSS Feed            | URL for an RSS feed that provides access to the dataset.                                                                                      | feed            
 System of Records   | If the systems is designated as a system of records under the Privacy Act of 1974, provide the URL to the System of Records Notice related to this dataset. | systemOfRecords
@@ -310,15 +309,6 @@ Field       | title
 **Accepted Values** | See Usage Notes
 **Usage Notes** | Distribution is a concatenation, as appropriate, of the following elements: download url, format, endpoint, language, size.
 **Example** | `"distribution": [{"accessURL": "http://data.mcc.gov/example_resource/data.json", "format":"JSON", "size":"22mb"},{"accessURL":"http://data.mcc.gov/example_/data.xml", "format":"XML", "size":"24mb"}]`
-
-{.table .table-striped}
-**Field** | **size**
------ | -----
-**Cardinality** | (0,n)
-**Required** | No
-**Accepted Values** | See Usage Notes
-**Usage Notes** | Sizes should be formatted as (e.g.), 52kB, 140MB, 2GB. 
-**Example** |  `{"size":"3MB"}`
 
 {.table .table-striped}
 **Field** | **landingPage**


### PR DESCRIPTION
Per the discussion in #55, :fire: the filesize field to the ground. Developers generally do not look to file size before using data, and it only serves to add complexity to the Agency's requirements.
