### PR TITLE
Fix RDF and Schema.org links in Metadata Resources

### DIFF
--- a/metadata-resources.md
+++ b/metadata-resources.md
@@ -73,14 +73,14 @@ In order to generate appropriately formatted XML or RDFa Lite files, simply impo
 {: .table .table-striped}
 Field               | *Data.gov*   | *CKAN* | *RDFa Lite 1.1*  | *Schema.org*
 -------             | -------                 | -------           | ------- | -------
-Title               | *Title*                 | *title*           | [dcterms:title](http://www.w3.org/TR/vocab-dcat/#property--title-1)    | *sdo:name*
-Description         | *Description*           | *notes*                | [dcterms:description](http://www.w3.org/TR/vocab-dcat/#property--description-1) | *sdo:description*
-Tags                | *Keywords*              | *tags*                | [dcat:keyword](http://www.w3.org/TR/vocab-dcat/#property--keyword-tag)    | *sdo:keywords*
-Last Update         | *Date updated*          | *revision_timestamp*                | [dcterms:modified](http://www.w3.org/TR/vocab-dcat/#property--update-modification-date-1) | *sdo:dateModified*
-Publisher           | *Agency Name*           | *owner_org*                | [dcat:publisher](http://www.w3.org/TR/vocab-dcat/#property--publisher-1) | *sdo:publisher*
-Contact Name        | *Contact Name*          | *maintainer*                | [foaf:Person](http://www.w3.org/TR/vocab-dcat/#class--organization-person) | *sdo:Person*
+Title               | *Title*                 | *title*           | [dcterms:title](http://www.w3.org/TR/vocab-dcat/#Property:distribution_title)    | [schema:name](http://schema.org/name)
+Description         | *Description*           | *notes*                | [dcterms:description](http://www.w3.org/TR/vocab-dcat/#Property:distribution_description) | [schema:description](http://schema.org/description)
+Tags                | *Keywords*              | *tags*                | [dcat:keyword](http://www.w3.org/TR/vocab-dcat/#Property:dataset_keyword)    | [schema:keywords](http://schema.org/keywords)
+Last Update         | *Date updated*          | *revision_timestamp*                | [dcterms:modified](http://www.w3.org/TR/vocab-dcat/#Property:distribution_update_date) | [schema:dateModified](http://schema.org/dateModified)
+Publisher           | *Agency Name*           | *owner_org*                | [dcterms:publisher](http://www.w3.org/TR/vocab-dcat/#Property:dataset_publisher) | [schema:publisher](http://schema.org/publisher)
+Contact Name        | *Contact Name*          | *maintainer*                | [dcat:contactPoint](http://www.w3.org/TR/vocab-dcat/#Property:dataset_contactPoint) | *n/a*
 Contact Email       | *Contact Email Address* | *maintainer_email*                | [foaf:mbox](http://xmlns.com/foaf/spec/#term_mbox) | *n/a*
-Unique Identifier   | *User Generated ID*     | *id*                | [dcterms:identifier](http://www.w3.org/TR/vocab-dcat/#property--identifier) | *n/a*
+Unique Identifier   | *User Generated ID*     | *id*                | [dcterms:identifier](http://www.w3.org/TR/vocab-dcat/#Property:dataset_identifier) | *n/a*
 Public Access Level | *n/a*                   | *n/a*             | *n/a* | *n/a*
 
 "Common Core" Required if Applicable Fields
@@ -92,13 +92,13 @@ Field               | *Data.gov*   | *CKAN* | *RDFa Lite 1.1* | *Schema.org*
 Bureau Code			| *n/a*                   | *n/a*             | *n/a* | *n/a*
 Program Code 		| *n/a*                   | *n/a*             | *n/a* | *n/a*
 Access Level Comment| *n/a*                   | *n/a*             | *n/a* | *n/a*
-Data Dictionary     | *Data Dictionary*       | *data_dict*                | [dcat:dataDictionary](http://www.w3.org/TR/vocab-dcat/#property--data-dictionary) | *n/a*
-Download URL        | *Access Point*          | *res_url*                | [dcat:accessURL](http://www.w3.org/TR/vocab-dcat/#property--access-download) | *sdo:contentUrl*
-Endpoint            | *Access Point*          | *res_url*                | [dcat:webService](http://www.w3.org/TR/vocab-dcat/#class--webservice) \*  | *n/a*
-Format              | *Media Format*          | *res_format*                | [dcterms:format](http://www.w3.org/TR/vocab-dcat/#property--format)      | *sdo:encodingFormat*
-License             | *Dataset license agreement URL* | *license_id*        | [dcterms:license](http://www.w3.org/TR/vocab-dcat/#property--license-1) | *n/a*
-Spatial             | *Geographic scope*      | *spatial*                | [dcterms:spatial](http://www.w3.org/TR/vocab-dcat/#property--spatial-geographical-coverage) | *ds:spatialCoverage*
-Temporal            | *Period of Coverage*    | *n/a*                | [dcterms:temporal](http://www.w3.org/TR/vocab-dcat/#property--temporal-coverage) | *ds:temporalCoverage*
+Data Dictionary     | *Data Dictionary*       | *data_dict*                | *n/a* | *n/a*
+Download URL        | *Access Point*          | *res_url*                | [dcat:accessURL](http://www.w3.org/TR/vocab-dcat/#Property:distribution_accessurl) | [schema:contentUrl](http://schema.org/contentUrl)
+Endpoint            | *Access Point*          | *res_url*                | *n/a* | *n/a*
+Format              | *Media Format*          | *res_format*                | [dcterms:format](http://www.w3.org/TR/vocab-dcat/#Property:distribution_format)      | [schema:encodingFormat](http://schema.org/encodingFormat)
+License             | *Dataset license agreement URL* | *license_id*        | [dcterms:license](http://www.w3.org/TR/vocab-dcat/#Property:catalog_license) | *n/a*
+Spatial             | *Geographic scope*      | *spatial*                | [dcterms:spatial](http://www.w3.org/TR/vocab-dcat/#Property:dataset_spatial) | [schema:spatial](http://schema.org/spatial)
+Temporal            | *Period of Coverage*    | *n/a*                | [dcterms:temporal](http://www.w3.org/TR/vocab-dcat/#Property:dataset_temporal) | [schema:temporal](http://schema.org/temporal)
 
 Expanded Fields
 ---------------
@@ -106,20 +106,14 @@ Expanded Fields
 {: .table .table-striped}
 Field               | *Data.gov*   | *CKAN* | *RDFa Lite 1.1* | *Schema.org*
 -------             | -------                 | -------           | -------  | -------
-Release Date        | *Date Released*         | *n/a*                | [dcterms:issued](http://www.w3.org/TR/vocab-dcat/#property--release-date) | *sdo:datePublished*
-Frequency           | *Frequency*             | *n/a*                | [dcterms:accrualPeriodicity](http://www.w3.org/TR/vocab-dcat/#property--frequency)    | *n/a*
-Language            | *n/a*                   | *n/a*                | [dcat:language](http://www.w3.org/TR/vocab-dcat/#property--language-1)     | *sdo:inLanguage*
-Granularity         | *Geographic Granularity* | *n/a*                | [dcat:granularity](http://www.w3.org/TR/vocab-dcat/#property--granularity) | *n/a*
-Data Quality        | *Data Quality*          | *n/a*                | [xsd:boolean](http://www.w3.org/TR/xmlschema-2/#boolean)  | *n/a*
-Category            | *Subject Area*          | *groups*                | [dcat:theme](http://www.w3.org/TR/vocab-dcat/#property--theme-category)   | *sdo:about*
-Related Documents   | *Reference for Technical Documentation* | *n/a*                | [dcterms:references](http://www.w3.org/TR/vocab-dcat/#property--related-documents) | *n/a*
-Size                | *File Size*             | *n/a*                | [dcat:size](http://www.w3.org/TR/vocab-dcat/#property--size) | *sdo:contentSize*
-Homepage URL        | *n/a*                  | *url*                | [dcat:landingPage](http://www.w3.org/ns/dcat#landingPage)  | *sdo:url*
-RSS Feed            | *Access Point*          | *n/a*                | [dcat:feed](http://www.w3.org/TR/vocab-dcat/#Class:_Feed) \*  | *n/a*
+Release Date        | *Date Released*         | *n/a*                | [dcterms:issued](http://www.w3.org/TR/vocab-dcat/#Property:distribution_release_date) | [schema:datePublished](http://schema.org/datePublished)
+Frequency           | *Frequency*             | *n/a*                | [dcterms:accrualPeriodicity](http://www.w3.org/TR/vocab-dcat/#Property:dataset_frequency)    | *n/a*
+Language            | *n/a*                   | *n/a*                | [dcterms:language](http://www.w3.org/TR/vocab-dcat/#Property:catalog_language)     | [schema:inLanguage](http://schema.org/inLanguage)
+Data Quality        | *Data Quality*          | *n/a*                | *n/a*  | *n/a*
+Category            | *Subject Area*          | *groups*                | [dcat:theme](http://www.w3.org/TR/vocab-dcat/#Property:dataset_theme)   | [schema:about](http://schema.org/about)
+Related Documents   | *Reference for Technical Documentation* | *n/a*                | [dcterms:references](http://dublincore.org/documents/dcmi-terms/#terms-references) | *n/a*
+Homepage URL        | *n/a*                  | *url*                | [dcat:landingPage](http://www.w3.org/ns/dcat#Property:dataset_landingpage)  | [schema:url](http://schema.org/url)
 System of Records   | *n/a*                  | *n/a*                | *n/a*  | *n/a*
-
-\*When combined with _accessURL_, _format_, and _size_.
-
 
 Mapping DCAT to Other Metadata Specifications
 ---------------------------------------------


### PR DESCRIPTION
This pull requests fixes a few small bugs:
- Several links to DCAT did not have up-to-date anchors.
- The original document did not have links to Schema.org terms. These have been added.
- `schema` is the usual namespace term for Schema.org, not `sdo` or `ds`.
- `publisher` belongs in the `dcterms` namespace, not the `dcat` namespace. Corrected.
- `dataDictionary`, `dataQuality`, `webService` do not exist in DCAT. Those links to DCAT are removed.
- `spatialCoverage` and `temporalCoverage` are actually named `spatial` and `temporal` on Schema.org.
- `dcat:contactPoint` had been added to the schema, and this change is now reflected here.
- Size, granularity and feed were removed from the schema, and therefore are removed here.

Follows from #57
