### PR TITLE
Fixes a bunch of markdown errors in /governance

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -5,36 +5,33 @@ permalink: /governance/
 filename: governance.md
 ---
 
-#Project Open Data Governance
-##Background
-Project Open Data is an online collection of code, best practices, and case studies developed to help agencies adopt the framework presented in the OMB memorandum M-13-13 “[Open Data Policy-Managing Information as an Asset] (/policy.md).” Project Open Data will evolve over time as a community resource to facilitate adoption of open data practices. To facilitate collaboration across the Federal Government and in partnership with public developers, the Project is published on the developer social network GitHub.
+# Project Open Data Governance
+## Background
+Project Open Data is an online collection of code, best practices, and case studies developed to help agencies adopt the framework presented in the OMB memorandum M-13-13 “[Open Data Policy-Managing Information as an Asset](/policy.md).” Project Open Data will evolve over time as a community resource to facilitate adoption of open data practices. To facilitate collaboration across the Federal Government and in partnership with public developers, the Project is published on the developer social network GitHub.
 
 As the Project founders, the Office of Management and Budget and the Office of Science and Technology Policy, components of the Executive Office of the President, are dedicated to maximizing openness, participation, and collaboration while ensuring the integrity of the resources hosted within the Project. This page provides information on ways to participate in the Project and how the OMB and OSTP will govern it.
 
 ##Contributing
 Project Open Data is a collaborative, open source project.  Both Federal employees and members of the public are strongly encouraged to improve the project by contributing.  Fortunately, contributing is very easy. Simply click the “Improve this content” button at the top of every page, make your edit, and hit “submit.” Your changes will appear once they are approved. Ultimately, the goal is for users to contribute to the project by suggesting changes to code/content (making “[pull requests](https://help.github.com/articles/using-pull-requests)”).
 However, there are many ways to participate:
+
 * _Browse_. Look around at the different resources available.
 * _Clone_. Copy code/content to your local machine. There is no official record in Project Open Data, and others cannot see what you do with the code/content.
 * _Fork_. Copy code/content to your own repo in GitHub, and make modifications there. Record of the fork is seen in Project Open Data, and others can see the code/content, but it now resides outsides the Project.
 * _Comment_. Comment on the code/content in Project Open Data using the issue tracker function. Others can see your suggested changes in a public log on Project Open Data. A moderator must accept, modify, or reject the comment in that public log.
 Contribute. Suggest changes to the code/content in Project Open Data by making a pull request. Others can see your suggested changes in a public log on Project Open Data. A moderator must accept, modify, or reject the suggested change in that public log before it becomes a part of the official code/content.
 
-##Owners
+## Owners
 Project Open Data is managed by the Office of Management and Budget (OMB) and Office of Science and Technology Policy (OSTP), both components of the Executive Office of the President. The Federal CIO and CTO will both be actively involved, along with members of their teams.
 
-##Approving Changes
+## Approving Changes
 In GitHub speak, Project Open Data is actually a collection of different little-p “projects” housed in individual repositories, or “repos.” Each individual project repo will be managed as an open source project – i.e., users can make pull requests (suggest changes). A repo manager will adjudicate the pull requests (accept, modify, or reject) in a public log on a standard release cycle. Proposed changes to relevant policy areas will be evaluated by relevant policy officials.  Information on the repo manager and release cycle for updates will be available in each repo’s documentation file. A program management office (PMO) in the General Services Administration (GSA) may be delegated management of individual technical repos, as well as provide daily technical oversight and user support for the Project.
 Given that the breadth of Project Open Data supports both technical and policy work, there will be different governance processes for each subject.
 
 * _Technical Repositories Governance & Review Cycle_ (e.g., source code, applications, best practices)– Technical repositories will be maintained by staff within the Office of Management and Budget and the Office of Science and Technology Policy, with support from technical staff at GSA (i.e., the Technical Review Committee). All comments and proposed changes from the public or other Federal employees will be reviewed regularly by the Technical Review Committee, on bi-weekly intervals. Additional stakeholders will be involved in review processes based on needed subject matter expertise. 
-
 * _Policy Related Repositories Governance & Release Cycle_ (e.g., open licensing, metadata)— Changes to repositories with implications for the policy must be approved by OMB and OSTP policy officials. All comments and proposed changes from the public or other Federal employees will be reviewed by the appropriate staff on bi-weekly intervals. Additional Federal stakeholders will be involved in review processes based on needed subject matter expertise. 
 
 There are two policies repos that will have very regulated release cycles:
 
 * _Common Core Metadata Schema_— Changes to the common core metadata schema will be reviewed on an ongoing basis. Starting November 9th, new releases of the schema will only be issued every 6 months, as needed. Suggested changes that alter implementation and structure of the schema will not be merged in-between the regular release cycles, though discussion and commenting during these periods are encouraged. Each version of the schema will have a depreciation date of one year.   
-
 * _The Open Data Policy M-13-13_— A version of The Open Data Policy (M-13-13) is available for public feedback and suggested changes through Project Open Data. Suggested changes to the policy will be reviewed bi-annually.  Adjudication times will depend on the extent of the suggested policy changes and decisions regarding the mechanism for dissemination (e.g., the need to consider updating official version of M-13-13, or other forms of guidance). Accepted changes to the policy will not be merged in-between the regular release cycles to prevent inconsistencies and confusion, though discussion and commenting during these periods are encouraged.
-
-


### PR DESCRIPTION
Some headers missing spaces, an unordered list missing a preceding newline, and a broken link.
