### PR TITLE
Updated api-basics.md: Repaired dead links by replacing them with links ...

### DIFF
--- a/api-basics.md
+++ b/api-basics.md
@@ -59,22 +59,21 @@ Many of these pioneers have shaped the way in which we develop, deploy, consume,
 
 ### What technology goes into an API?
 
-APIs are driven by a set of specific technologies, making them easily understood by developers. This type of standardization means that APIs can work with common programming languages. The most popular approach to delivering web APIs is:
+APIs are driven by a set of specific technologies, making them easily understood by developers.  This type of focus means that APIs can work with any common programming language, with the most popular approach to delivering web APIs being REST, or [REpresentational State Transfer](http://en.wikipedia.org/wiki/Representational_state_transfer).
 
-*	[Pragmatic REST](http://apievangelist.com/buildingblocks/pragmatic_rest.php)
+REST takes advantage of the same Internet mechanisms that are used to view regular web pages, giving it many advantages, that can result in faster implementations and easier for developers to understand and use. REST APIs allow you to take data and functionality that may already be available on your website and make them available through a programmatic API, that both web and mobile applications can use. Then, instead of returning HTML to represent the information like a website would, an API returns data in one of two possible formats:
+* [Extensible Markup Language (XML)](http://en.wikipedia.org/wiki/Xml)
+* [JavaScript Object Notation (JSON)](http://en.wikipedia.org/wiki/JSON)
 
-Since REST takes advantage of the same Internet mechanisms that are used to view regular web pages it has many advantages, resulting in faster implementations and and ease of use for developers. REST APIs allow you to take data and functionality available on your website and make these resources available through a Web API.  Then, instead of returning HTML to represent these resources, the API returns data in one of two possible formats:
+Developers can then take this data and use in web and mobile applications.  However XML and JSON are easily consumed by spreadsheets and other tools non-developers can use as well, making APIs accessible by potentially anyone.  
 
-<ul>
-  <li><a href="http://apievangelist.com/buildingblocks/extensible_markup_language_(xml).php">Extensible Markup Language (XML)</a></li>
-  <li><a href="http://apievangelist.com/buildingblocks/javascript_object_notation_(json).php">JavaScript Object Notation (JSON)</a></li>
-</ul>
+Easy access to all this data and resources is great, but sometimes we need to control access to APIs. There are two primary ways to secure an API by providing  authentication using:
+* [Basic Auth](http://en.wikipedia.org/wiki/Basic_auth)
+* [OAuth](http://en.wikipedia.org/wiki/Oauth)
 
-Developers can then take this data and use it in web and mobile applications. In addition, XML and JSON are easily consumed by spreadsheets and other tools non-developers can use as well, making APIs accessible by anyone.  
+REST with JSON has become the favorite of developers and API owners, because it is easier to both deploy and consume than other implementations. Even though REST + JSON is not a standard, it is seeing wide acceptance across the industry.
 
-
-REST with JSON has become the favorite of developers and API owners because it is easier to both deploy and consume than other implementations. Even though REST + JSON is not a standard, it is seeing wide acceptance across the industry.
-
+The technology that are commonly found in APIs was not designated by a single standards body or by a single company, it is based upon emulating the best practices of existing, successful providers over the last 13 years.
 ### When Things Go Wrong — Error Handling
 
 One of the most important issues to remember in API strategy is that developers need to handle what happens when an error occurs otherwise access to data fails and subsequently so does the application. For the purposes of the service framework, an error is defined as an unexpected behavior that occurred during the process of a request. It's important to note that what might be considered an "error" can often be an expected behavior.


### PR DESCRIPTION
...to Wikipedia.  The old links in that section were pointing to pages on apievangelist.com that no longer existed.  Upon examining the front page content of that site, I saw a similar section that seemed to be the inspiration of this section of the docuemtn, so I grabbed the latest content paragraphs from apievangelist.com as well for the section "What tech. goes into an API?"
