### PR TITLE
2 small fixes to /schema

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -290,7 +290,7 @@ Further Metadata Field Guidance (alphabetical by JSON field)
 **Cardinality** | (0,1)
 **Required** | No
 **Accepted Values** | String
-**Usage Notes** | Use to link a given dataset with its related IT Unique Investment Identifier, which can often be found in Exhibit 300 documents.
+**Usage Notes** | Use to link a given dataset with its related IT Unique Investment Identifier, which can often be found in Exhibit 53 documents.
 **Example** |  `{"PrimaryITInvestmentUII":"123456"}`
 
 {: .table .table-striped}


### PR DESCRIPTION
Moved the Further Metadata Guidance for programCode to keep it in alphabetical order and added a mention to Exhibit 300 documents for the Primary IT UII.  
