### PR TITLE
Added reference to CSV and removed reference to XML, RDF-A

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -394,6 +394,5 @@ Additional Information
 
 Examples
 --------
-* [CSV](/metadata-resources/)
-* [JSON](/metadata-resources/)
+CSV and JSON template and example files can be found on the [Metadata Resources page](/metadata-resources/).
 


### PR DESCRIPTION
Just fixing a legacy reference to the file formats of the sample files at /metadata-resources
