### PR TITLE
Fix broken link to "Sample Procedure for an agency-wide data call"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,3 +14,4 @@ prose_url: http://prose.io
 pymgemnts: true
 exclude: ["script", "vendor", "Gemfile", "Gemfile.lock", "config.ru", "Procfile", "Rakefile", "readme.md"]
 markdown: kramdown
+relative_permalinks: false

--- a/assets/docs/sample_data_call_procedure.md
+++ b/assets/docs/sample_data_call_procedure.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Sample Procedure for a data call
-permalink: /assets/docs/sample_data_call_procedure
+permalink: /assets/docs/sample_data_call_procedure/
 filename: sample_data_call_procedure.md
 ---
 

--- a/policy-docs.md
+++ b/policy-docs.md
@@ -21,5 +21,5 @@ This section offers examples of policy documents (memos, guidance, manuals, etc)
 
 ## Guidance
 
-* [Sample Procedure for an agency-wide data call](http://project-open-data.github.io/assets/docs/sample_data_call_procedure).  
+* [Sample Procedure for an agency-wide data call](/assets/docs/sample_data_call_procedure/).
 


### PR DESCRIPTION
The link to the "Sample Procedure for an agency-wide data call" page at the bottom of the [policy docs page](http://project-open-data.github.io/policy-docs/) is currently broken.

With the current configuration, Jekyll is actually generating the page as a non-servable file off at: http://project-open-data.github.io/assets/docs/assets/docs/sample_data_call_procedure To fix this, I added a trailing slash to the permalink and also disabled the global `relative_permalinks` option.

Disabling relative permalinks is recommend and [will be the default in Jekyll 2.0](http://jekyllrb.com/docs/upgrading/#absolute_permalinks). Although this is a change to a global setting, I did some diffs, and I'm pretty sure this sample data call page is the only page affected by changing that setting (all the other permalink settings are at the root of the project where absolute and relative permalinks would be the same anyway).
