### PR TITLE
fixing markdown in front of 'background'

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -14,7 +14,7 @@ Project Open Data is an online collection of code, best practices, and case stud
 As the Project founders, the Office of Management and Budget and the Office of Science and Technology Policy, components of the Executive Office of the President, are dedicated to maximizing openness, participation, and collaboration while ensuring the integrity of the resources hosted within the Project. This page provides information on ways to participate in the Project and how the OMB and OSTP will govern it.
 
 ##Contributing
-Project Open Data is a collaborative, open source project.  Both Federal employees and members of the public are strongly encouraged to improve the project by contributing.  Fortunately, contributing is very easy. Simply click the “Improve this content” button at the top of every page, make your edit, and hit “submit.” Your changes will appear once they are approved. Ultimately, the goal is for users to contribute to the project by suggesting changes to code/content (making “[pull requests](https://help.github.com/articles/using-pull-requests)”).
+Project Open Data is a collaborative, open source project.  Both Federal employees and members of the public are strongly encouraged to improve the project by contributing.  Fortunately, contributing is very easy. Simply log into GitHub, click the “Improve this content” button at the top of every page, make your edit, and hit “submit.” Your changes will appear once they are approved. Ultimately, the goal is for users to contribute to the project by suggesting changes to code/content (making “[pull requests](https://help.github.com/articles/using-pull-requests)”).
 However, there are many ways to participate:
 
 * _Browse_. Look around at the different resources available.


### PR DESCRIPTION
The hashtags in front of 'background' are showing up as hashtags and not working as a header on the website, but they're working fine in preview. Hoping this fixes it.
