### PR TITLE
Emphasize license-free when discussing license examples

### DIFF
--- a/license-examples.md
+++ b/license-examples.md
@@ -15,7 +15,7 @@ Data and content created by government employees within the scope of their emplo
 
 When acquiring data or content from third-parties, however, care must be taken to ensure use of the work by the public is possible and not restricted by a non-open copyright license. While an [open license](/licenses/), as defined by [M-13-13](/policy-memo/), is now a minimum requirement, agencies should strongly consider making this data "license-free," i.e. in the public domain, along with the works created by the agency itself.
 
-A worldwide public domain dedication such as [CC0](http://creativecommons.org/publicdomain/zero/1.0/) is recommended by a coalition of non-governmental organizations in this [guidance on making government data license-free](http://theunitedstates.io/licensing/), which includes best practices language, examples, and rationale.
+A worldwide public domain dedication such as [CC0](http://creativecommons.org/publicdomain/zero/1.0/) is recommended by a coalition of non-governmental organizations in this [guidance on making government data license-free](http://theunitedstates.io/licensing/), which includes best practices language, real world government examples, and rationale.
 
 When using a license instead, in general such licenses should comply with [the Open Knowledge definition](http://opendefinition.org/okd/) of an open license.
 

--- a/license-examples.md
+++ b/license-examples.md
@@ -5,21 +5,29 @@ permalink: /license-examples/
 filename: license-examples.md
 ---
 
-This section offers usable examples of open licenses for potential use by agencies.  
+This section offers usable examples of open licenses and public domain dedications for potential use by agencies.
 
 ## Generally
 
-Data and content created by government employees within the scope of their employment are not subject to domestic copyright protection under 17 U.S.C. § 105. When purchasing data or content from third-party vendors, however care must be taken to ensure the information is not hindered by a restrictive, non-open license. In general, such licenses should comply with [the open knowledge definition](http://opendefinition.org/okd/) of an open license. Several examples of common open licenses are listed below:
+Data and content created by government employees within the scope of their employment are not subject to domestic copyright protection under 17 U.S.C. § 105. When purchasing data or content from third-party vendors, however care must be taken to ensure the information is not hindered by a restrictive, non-open license.
+
+Agencies should strongly consider making their data entirely license-free, using a worldwide public domain dedication such as [CC0](http://creativecommons.org/publicdomain/zero/1.0/). See this [guidance on making government data license-free](http://theunitedstates.io/licensing/) for best practices language, examples, and rationale.
+
+When using a license, in general such licenses should comply with [the Open Knowledge definition](http://opendefinition.org/okd/) of an open license.
+
+Several examples of common public domain dedications and open licenses are listed below:
+
+## Public Domain Dedications
+* [Creative Commons Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/) (CC0)
 
 ## Content Licenses
-* [Creative Commons BY, BY-SA, or CC0](http://creativecommons.org/choose/)
+* [Creative Commons BY, BY-SA](http://creativecommons.org/choose/)
 * [GNU Free Documentation License](http://www.gnu.org/licenses/fdl-1.3.en.html)
 
 ## Data Licenses
 * [Open Data Commons Public Domain Dedication and Licence (PDDL)](http://opendefinition.org/licenses/odc-pddl)
 * [Open Data Commons Attribution License](http://opendatacommons.org/licenses/by/)
 * [Open Data Commons Open Database License (ODbL)](http://opendatacommons.org/licenses/odbl/)
-* [Creative Commons CC0 Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/)
 
 ## More Information
 *[Extended list of conformant licenses](http://opendefinition.org/licenses/)*


### PR DESCRIPTION
This pull request by @JoshData and I updates the license examples page to explicitly recommend making an agency's data free of licensing, through a worldwide public domain dedication.

This isn't a very radical suggestion - CC0 and the PDDL are already listed on the license examples page. However, CC0 and PDDL are not licenses, but an explicit avoidance of licensing, so I've also updated the list to reflect that, and move CC0 and PDDL to their own section. HHS and the CFPB have both already made some of their work license-free via CC0.

This PR includes a link to the [government data licensing guidance](http://theunitedstates.io/licensing/) that a large number of non-governmental public interest groups signed on to in December. Some of the real world HHS and CFPB examples are referenced there, along with this project itself.