### PR TITLE
JSON schema corrections

### DIFF
--- a/schema/1_0_final/single_entry.json
+++ b/schema/1_0_final/single_entry.json
@@ -28,8 +28,15 @@
         "accessURL": {
             "title":"Download URL",
             "description":"URL providing direct access to the downloadable distribution of a dataset.",
-            "type": "string",
-            "format": "uri"
+            "anyOf": [
+                {
+                   "type": "string",
+                   "format": "uri"
+                },
+                {
+                    "type": "null"                    
+                }
+              ]            
         },       
         "accrualPeriodicity": {
             "title":"Frequency",
@@ -133,8 +140,15 @@
         "format": {
             "title":"Format",
             "description":"The file format or API type of the distribution.",
-            "pattern": "^[-\\w]+/[-\\w]+(\\.[-\\w]+)*([+][-\\w]+)?$",
-            "type": "string"
+            "anyOf": [
+                {
+                    "pattern": "^[-\\w]+/[-\\w]+(\\.[-\\w]+)*([+][-\\w]+)?$",
+                    "type": "string"
+                },
+                {
+                    "type": "null"                    
+                }
+              ]             
         },         
         "identifier": {
             "title":"Unique Identifier",


### PR DESCRIPTION
Fixes a few things: 
1. Prevent schema from accepting null values for `keyword` which should always be required. Allowing it to be null was an oversight in the update on #269 
2. Make sure each entry in `keyword` is at least one character long (prevents empty strings)
3. If `distribution` is used then ensure that both `accessURL` and `format` are included 
4. Defines regular expression pattern for `PrimaryITInvestmentUII` as mentioned in #283 and #282
5. Adds `accessURL` and `format` as possible fields outside of `distribution` (but can be null)
6. Made it so a `keyword` doesn't have to be unique as discussed in #288 
