### PR TITLE
Added URL to site on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,11 @@ Contributions can be made, primarily in two ways:
 
 ### Easy
 
-1. Click the "Improve this content" button in the top right corner of any page
-2. Make changes as you would normally
-3. Click "Submit".
-4. You change should appear once approved.
+1. Browse the content at http://project-open-data.github.io/
+2. Click the "Improve this content" button in the top right corner of any page
+3. Make changes as you would normally
+4. Click "Submit".
+5. You change should appear once approved.
 
 *Note: You may need to [create a free GitHub account](https://github.com/signup/free) if you do not already have one*
 


### PR DESCRIPTION
No where on the github repo could I find a link to the site. I had to look through the pull requests to find out how to see the content. I added a link on the contribute page that provides at least a little information on how to get to the site.
