### PR TITLE
Fix licensing resources page

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,13 +8,13 @@ title: Project Open Data
 
 ##1. Background
 
-Data is a valuable national resource and a strategic asset to the U.S. Government, its partners, and the public.  Managing this data as an asset and making it available, discoverable, and usable – [in a word, open](principles/) – not only strengthens our democracy and promotes efficiency and effectiveness in government, but also has the potential to create economic opportunity and improve citizens’ quality of life. 
+Data is a valuable national resource and a strategic asset to the U.S. Government, its partners, and the public.  Managing this data as an asset and making it available, discoverable, and usable – [in a word, open](principles/) – not only strengthens our democracy and promotes efficiency and effectiveness in government, but also has the potential to create economic opportunity and improve citizens’ quality of life.
 
-For example, when the U.S. Government released weather and GPS data to the public, it fueled an industry that today is valued at tens of billions of dollars per year. Now, weather and mapping tools are ubiquitous and help everyday Americans [navigate their lives](business-case/). 
+For example, when the U.S. Government released weather and GPS data to the public, it fueled an industry that today is valued at tens of billions of dollars per year. Now, weather and mapping tools are ubiquitous and help everyday Americans [navigate their lives](business-case/).
 
-The ultimate value of data can often not be predicted. That’s why the U.S. Government released a [policy](policy-memo/) that instructs agencies to manage their data, and information more generally, as an asset from the start and, wherever possible, release it to the public in a way that makes it open, discoverable, and usable. 
+The ultimate value of data can often not be predicted. That’s why the U.S. Government released a [policy](policy-memo/) that instructs agencies to manage their data, and information more generally, as an asset from the start and, wherever possible, release it to the public in a way that makes it open, discoverable, and usable.
 
-The White House developed Project Open Data – this collection of code, tools, and case studies – to help agencies adopt the Open Data Policy and unlock the potential of government data. Project Open Data will evolve over time as a community resource to facilitate broader adoption of open data practices in government. Anyone – government employees, contractors, developers, the general public – can view and contribute. Learn more about [Project Open Data Governance](governance/) and dive right in and help to build a better world through the power of open data. 
+The White House developed Project Open Data – this collection of code, tools, and case studies – to help agencies adopt the Open Data Policy and unlock the potential of government data. Project Open Data will evolve over time as a community resource to facilitate broader adoption of open data practices in government. Anyone – government employees, contractors, developers, the general public – can view and contribute. Learn more about [Project Open Data Governance](governance/) and dive right in and help to build a better world through the power of open data.
 
 ----------------
 
@@ -24,43 +24,43 @@ This section is a list of definitions and principles used to guide the project.
 
 2-1 [Open Data Principles](principles/) - The set of open data principles.
 
-2-2 [Standards, Specifications, and Formats](open-standards/) - Standards, specifications, and formats supporting open data objectives.   
+2-2 [Standards, Specifications, and Formats](open-standards/) - Standards, specifications, and formats supporting open data objectives.
 
 2-3 [Open Data Glossary](glossary/) - The glossary of open data terms.
 
-2-4 [Open Licenses](open-licenses/) - The definition for open licenses. 
+2-4 [Open Licenses](open-licenses/) - The definition for open licenses.
 
-2-5 [Common Core Metadata](schema/) - The schema used to describe datasets, APIs, and published data at agency.gov/data.  
+2-5 [Common Core Metadata](schema/) - The schema used to describe datasets, APIs, and published data at agency.gov/data.
 
 ----------------
 
 ##3. Implementation Guidance
 
-Implementation guidance for open data practices.  
+Implementation guidance for open data practices.
 
-3-1 [U.S. Government Policy on Open Data](/policy-memo/) - Full text of the memorandum.  
+3-1 [U.S. Government Policy on Open Data](/policy-memo/) - Full text of the memorandum.
 
-3-2 [Implementation Guide](/implementation-guide/) - Official OMB implementation guidance for each step of implementing the policy. 
+3-2 [Implementation Guide](/implementation-guide/) - Official OMB implementation guidance for each step of implementing the policy.
 
-3-3 [Public Data Listing](/catalog/) - The specific guidance for publishing the Open Data Catalog at the agency.gov/data page.  
+3-3 [Public Data Listing](/catalog/) - The specific guidance for publishing the Open Data Catalog at the agency.gov/data page.
 
-3-4 [Frequently Asked Questions](/faq/) - A growing list of common questions and answers to facilitate adoption of open data projects.  
+3-4 [Frequently Asked Questions](/faq/) - A growing list of common questions and answers to facilitate adoption of open data projects.
 
-3-5 [Open Data Cross Priority (CAP) Goal](http://goals.performance.gov/opendata) - Information on the development of the Open Data CAP goal as required in the [Open Data Executive Order](http://www.whitehouse.gov/the-press-office/2013/05/09/executive-order-making-open-and-machine-readable-new-default-government). 
+3-5 [Open Data Cross Priority (CAP) Goal](http://goals.performance.gov/opendata) - Information on the development of the Open Data CAP goal as required in the [Open Data Executive Order](http://www.whitehouse.gov/the-press-office/2013/05/09/executive-order-making-open-and-machine-readable-new-default-government).
 
 ----------------
 
-##4. Tools 
+##4. Tools
 
 This section is a list of ready-to-use solutions or tools that will help agencies jump-start their open efforts.  These are real, implementable, coded solutions that were developed to significantly reduce the barrier to implementing open data at your agency.  Many of these tools are hosted at [Labs.Data.gov](http://labs.data.gov) and developers are encouraged to contribute improvements to them and contribute other tools which help us implement the spirit of Project Open Data.
 
 4-1 [Database to API](https://github.com/project-open-data/db-to-api) - Dynamically generate RESTful APIs from the contents of a database table. Provides JSON, XML, and HTML. Supports most popular databases. -&nbsp;*[Hosted](http://labs.data.gov/db-to-api/readme.md)*
- 
+
 4-2 [CSV to API](https://github.com/project-open-data/csv-to-api) - Dynamically generate RESTful APIs from static CSVs. Provides JSON, XML, and HTML. -&nbsp;*[Hosted](http://labs.data.gov/csv-to-api/)*
 
 4-3 [Spatial Search](https://github.com/project-open-data/SpatialSearch) - A RESTful API that allows the user to query geographic entities by latitude and longitude, and extract data.
 
-4-4 [Kickstart](https://github.com/project-open-data/kickstart) - A WordPress plugin to help agencies kickstart their open data efforts by allowing citizens to browse existing datasets and vote for suggested priorities.  
+4-4 [Kickstart](https://github.com/project-open-data/kickstart) - A WordPress plugin to help agencies kickstart their open data efforts by allowing citizens to browse existing datasets and vote for suggested priorities.
 
 4-5 [PDF Filler](https://github.com/project-open-data/pdf-filler) - PDF Filler is a RESTful service (API) to aid in the completion of existing PDF-based forms and empower web developers to use browser-based forms and modern web standards to facilitate the collection of information. -&nbsp;*[Hosted](http://labs.data.gov/pdf-filler)*
 
@@ -70,7 +70,7 @@ This section is a list of ready-to-use solutions or tools that will help agencie
 
 4-8 [Project Open Data Dashboard](http://data.civicagency.org) - A dashboard to check the status of /data and /data.json at each agency. This also includes a validator.
 
-4-9 [Data.json File Merger](http://data.json.file.merger.ongithub.com/) - Allows the easy combination of multiple data.json files from component agencies or bureaus into one combined file.  
+4-9 [Data.json File Merger](http://data.json.file.merger.ongithub.com/) - Allows the easy combination of multiple data.json files from component agencies or bureaus into one combined file.
 
 4-10 [API Sandbox](http://project-open-data.github.com/api-sandbox) - Interactive API documentation systems.
 
@@ -88,9 +88,9 @@ This section is a list of ready-to-use solutions or tools that will help agencie
 
 4-17 [Esri Geoportal Server](https://github.com/Esri/geoportal-server/) - Open source catalog supporting ISO/FGDC/DC/... metadata with mapping to DCAT to support agency.gov/data.json listings in addition to providing [OGC CSW](http://www.opengeospatial.org/standards/cat), [OAI-PMH](http://www.openarchives.org/pmh/) and [OpenSearch](http://www.opensearch.org). Supports automated harvesting from other open catalog sources.
 
-4-18 [Libre Information Batch Restructuring Engine](https://github.com/commonwealth-of-puerto-rico/libre) - Open data conversion and API tool, created by the Office of the Chief Information Officer of the Commonwealth of Puerto Rico.  
+4-18 [Libre Information Batch Restructuring Engine](https://github.com/commonwealth-of-puerto-rico/libre) - Open data conversion and API tool, created by the Office of the Chief Information Officer of the Commonwealth of Puerto Rico.
 
-4-19 [JSON-to-CSV Converter](http://konklone.io/json/) - A handy means of converting data.json files to a spreadsheet-friendly format.  A [similar tool](http://shancarter.github.io/mr-data-converter/) can provide basic CSV-to-JSON functionality.  
+4-19 [JSON-to-CSV Converter](http://konklone.io/json/) - A handy means of converting data.json files to a spreadsheet-friendly format.  A [similar tool](http://shancarter.github.io/mr-data-converter/) can provide basic CSV-to-JSON functionality.
 
 ----------------
 
@@ -98,14 +98,14 @@ This section is a list of ready-to-use solutions or tools that will help agencie
 
 This section contains programmatic tools, resources, and/or checklists to help programs determine open data requirements.
 
-5-1 [Metadata Resources](metadata-resources/) - 
-Resources to provide guidance and assistance for each aspect of creating and maintaining agency.gov/data catalog files.  
+5-1 [Metadata Resources](metadata-resources/) -
+Resources to provide guidance and assistance for each aspect of creating and maintaining agency.gov/data catalog files.
 
-5-2 [Business Case for Open Data](business-case/) - Overview of the benefits associated with open data.  
+5-2 [Business Case for Open Data](business-case/) - Overview of the benefits associated with open data.
 
-5-3 [General Workflows for Open Data Projects](future-case-study/) - A comprehensive overview of the steps involved in open data projects and their associated benefits.  
+5-3 [General Workflows for Open Data Projects](future-case-study/) - A comprehensive overview of the steps involved in open data projects and their associated benefits.
 
-5-4 [Open License Examples](license-examples/) - Potential licenses for data and content.  
+5-4 [Open License Examples](license-examples/) - Potential licenses for data and content.
 
 5-5 [API Basics](api-basics/) - Introductory resources for understanding application programming interfaces (APIs).
 
@@ -113,13 +113,13 @@ Resources to provide guidance and assistance for each aspect of creating and mai
 
 5-7 [Digital PII Checklist](digital-pii-checklist/) - Tool to assist agencies identify personally identifiable information in data.
 
-5-8 [Applying the Open Data Policy to Federal Awards: FAQ](federal-awards-faq/) - Frequently asked questions for contracting officers, grant professionals and the federal acquisitions community on applying the Open Data Policy to federal awards. 
+5-8 [Applying the Open Data Policy to Federal Awards: FAQ](federal-awards-faq/) - Frequently asked questions for contracting officers, grant professionals and the federal acquisitions community on applying the Open Data Policy to federal awards.
 
 5-9 [Example Policy Documents](policy-docs/) - Collection of memos, guidance and policy documents about open data for reference.
 
 5-10 [Example Data Hubs](/data-hubs) - Collection of department, agency, and program data sites across the federal government.
 
-5-11 [Licensing policies, principles, and resources](/licensing-resources.md) - Some examples of how government has addressed open licensing questions.
+5-11 [Licensing policies, principles, and resources](/licensing-resources) - Some examples of how government has addressed open licensing questions.
 
 ----------------
 
@@ -129,11 +129,11 @@ Case studies of novel or best practices from agencies who are leading in open da
 
 6-1 [Department of Labor API Program](labor-case-study/) - A department perspective on developing APIs for general use and, in particular, building the case for an ecosystem of users by developing SDKs.
 
-6-2 [Department of Transportation Enterprise Data Inventory](transportation-case-study/) - A review of DOT's strategy and policy when creating a robust data inventory program.  
+6-2 [Department of Transportation Enterprise Data Inventory](transportation-case-study/) - A review of DOT's strategy and policy when creating a robust data inventory program.
 
-6-3 [Disaster Assistance Program Coordination](fema-case-study/) - The coordinated campaign led by FEMA has integrated a successful data exchange among 16 agencies to coordinate an important public service.  
+6-3 [Disaster Assistance Program Coordination](fema-case-study/) - The coordinated campaign led by FEMA has integrated a successful data exchange among 16 agencies to coordinate an important public service.
 
-6-4 [Environmental Protection Agency Central Data Exchange](epa-case-study/) - The agency's data exchange provides a model for programs that seek to coordinate the flow of data among industry, state, local, and tribal entities.  
+6-4 [Environmental Protection Agency Central Data Exchange](epa-case-study/) - The agency's data exchange provides a model for programs that seek to coordinate the flow of data among industry, state, local, and tribal entities.
 
 6-5 [FederalRegister.gov API](https://www.federalregister.gov/uploads/2012/11/FR2-API-Case-Study1.pdf) - A core government program update that has grown into an important public service.
 

--- a/licensing-resources.md
+++ b/licensing-resources.md
@@ -1,10 +1,16 @@
-# Licensing Policies, Principles, and Resources
-####*Some examples of how government has addressed open licensing questions*
+---
+layout: default
+title: Licensing Policies, Principles, and Resources
+permalink: /licensing-resources/
+filename: licensing-resources.md
+---
 
-###[Grants and Grantees Solicitation and Agreement Clauses](http://www.doleta.gov/grants/pdf/SGA-DFA-PY-13-10.pdf)   
+Some examples of how government has addressed open licensing questions.
+
+###[Grants and Grantees Solicitation and Agreement Clauses](http://www.doleta.gov/grants/pdf/SGA-DFA-PY-13-10.pdf)
 *Department of Labor*
-	
-This is a policy requiring a grant’s recipients to license to the public all new content created and modified with grant funds using a Creative Commons Attribution license.  The policy is designed so that the investment of grant funds has as broad an impact as possible, maximizing the value of materials developed and offered through the grant program by encouraging innovation in the development of new learning materials.  The Creative Commons Attribution license ensures that materials developed with funds provided by these grants result in work that can be freely reused and improved by others and was chosen because it is a globally recognized standard that gives members of the public broad permission for reuse, as long as credit is given to the creators, as directed by licensor.  
+
+This is a policy requiring a grant’s recipients to license to the public all new content created and modified with grant funds using a Creative Commons Attribution license.  The policy is designed so that the investment of grant funds has as broad an impact as possible, maximizing the value of materials developed and offered through the grant program by encouraging innovation in the development of new learning materials.  The Creative Commons Attribution license ensures that materials developed with funds provided by these grants result in work that can be freely reused and improved by others and was chosen because it is a globally recognized standard that gives members of the public broad permission for reuse, as long as credit is given to the creators, as directed by licensor.
 
 The policy also requires that the grantees release all software code created with the funds under a license that allows others to use and build upon them and that all grantees must release all new source code developed or created with the grant funds under an open license acceptable to either the Free Software Foundation and/or the Open Source Initiative.
 
@@ -13,13 +19,13 @@ The policy also requires that the grantees release all software code created wit
 
 An open letter on licensing best practices developed by a collaboration of civil society groups — GovTrack.us, Creative Commons, the Sunlight Foundation, the Open Knowledge Foundation, the Electronic Frontier Foundation, and Public Knowledge — inspired by the Open Data Policy. It includes model clauses from across the government, to address a range of works and situations: e.g. US government works, contractor-created works, click-through agreements, and software. The letter is hosted at http://theunitedstates.io which is not an organization, but a shared commons of data and tools for the United States - made by the public, used by the public. It is managed through GitHub, and intended to be regularly updated.
 
-###[U.S. Open Data Action Plan](http://www.whitehouse.gov/sites/default/files/microsites/ostp/us_open_data_action_plan.pdf) 
-*The U.S. Government*   
+###[U.S. Open Data Action Plan](http://www.whitehouse.gov/sites/default/files/microsites/ostp/us_open_data_action_plan.pdf)
+*The U.S. Government*
 
 Commitments that the U.S. Government has made to advance Open Data, and selected examples of expansions, enhancements, and upcoming releases of data sets in categories of the Open Data Charter. The license for each forthcoming data release are detailed; the listed data sets are primarily 1) in the public domain, 2) to be released into the public domain through a “CC0” or Creative Commons Zero public domain dedication, or 3) to be released under a “CC-BY” or Creative Commons Attribution license that permits any form of reuse otherwise regulated by copyright provided that downstream users give appropriate credit as directed by the licensor.
 * [U.S. Open Data Action Plan - High Value Datasets Appendix](http://www.whitehouse.gov/sites/default/files/docs/us_open_data_action_plan_high_value_datasets.csv)
 
- 
+
 ###[Model Terms of Service for Open Data APIs](https://github.com/seanherron/API-Resources/blob/revised_draft_tos/developer_tos/vanilla_tos.md)
 *openFDA*
 
@@ -30,23 +36,23 @@ A model Terms of Service document for APIs (Application Programming Interfaces, 
 
 Guidance clarifying how existing law and regulations apply to the use and publication of Open Source Software (OSS) developed at the Department of Defense. The guidance addresses the use of open source software and the release of government-developed software as open source. In particular, the guidance explains that Open Source Software meets the legal definition of "Commercial Computer Software" (48 CFR 2.101(b)), and the statutory preference for acquisition of commercial items therefore applies to OSS.  Likewise, the legal requirement (41 USC 253a) to conduct market research for commercial items means that open source software must be considered in the acquisition planning process, and the memorandum further notes a variety of advantageous aspects for open source software that should be considered.  With respect to open data, the memo notes that software source code and design documents are themselves "data" and thus existing guidance promoting sharing of data applies to software source code, and further notes that open source software licensing provides an effective model to achieve those goals.
 
-The guidance provides a framework for the decision of the government to release software to the public (as open source), based on following three criteria: 1) the project manager or comparable official decides that it is in the government's interests to do so; 2) the government has the appropriate data rights to release the software; 3) the release of the software is not restricted by other law or regulation, particularly export control under the Export Administration Regulations or the International Traffic in Arms Regulation. 
+The guidance provides a framework for the decision of the government to release software to the public (as open source), based on following three criteria: 1) the project manager or comparable official decides that it is in the government's interests to do so; 2) the government has the appropriate data rights to release the software; 3) the release of the software is not restricted by other law or regulation, particularly export control under the Export Administration Regulations or the International Traffic in Arms Regulation.
 
 ###[Use of External Open Source Software Policy](https://github.com/cfpb/source-code-policy/blob/master/cfpb-source-code-policy.txt)
 *Consumer Finance Protection Bureau*
 
-Policy that references legal and practical considerations in researching and procuring software, keeping in mind open source options.  
+Policy that references legal and practical considerations in researching and procuring software, keeping in mind open source options.
 
-###[Open Source Software FAQs](http://dodcio.defense.gov/OpenSourceSoftwareFAQ.aspx)   
-*Department of Defense*   
+###[Open Source Software FAQs](http://dodcio.defense.gov/OpenSourceSoftwareFAQ.aspx)
+*Department of Defense*
 
-An educational resource for government employees and government contractors to understand the policies and legal issues relating to the use of open source software in the DoD.  Much of the information collected there is applicable to other Federal agencies.   The FAQ covers a range of issues, including:  DoD policy on OSS, general information about OSS, OSS licenses, release of government software as OSS, and OSS-like approaches used within the Federal government. 
-* [Working Version of the FAQs](http://risacher.github.io/DoD-OSS-FAQ/) 
+An educational resource for government employees and government contractors to understand the policies and legal issues relating to the use of open source software in the DoD.  Much of the information collected there is applicable to other Federal agencies.   The FAQ covers a range of issues, including:  DoD policy on OSS, general information about OSS, OSS licenses, release of government software as OSS, and OSS-like approaches used within the Federal government.
+* [Working Version of the FAQs](http://risacher.github.io/DoD-OSS-FAQ/)
 
 ###[How to FOSS Your Government Project](http://bit.ly/HowToFOSS)
 *National Security Agency & DoD CIO*
 
-A checklist developed at NSA to document the internal processes required to release government-developed software as open source software.  It provides a detailed example for other agencies to use as a starting point.  The original document contained a number of NSA-specific processes, the linked document is a "template" version that removes the specifics, and leaves just the outline and advisory material.  
+A checklist developed at NSA to document the internal processes required to release government-developed software as open source software.  It provides a detailed example for other agencies to use as a starting point.  The original document contained a number of NSA-specific processes, the linked document is a "template" version that removes the specifics, and leaves just the outline and advisory material.
 
 
 


### PR DESCRIPTION
The just-merged PR, #312 (which is terrific, BTW, :+1:) links to a raw Markdown file ([/licensing-resources.md](http://project-open-data.github.io/licensing-resources.md)) by mistake. This PR updates the link to `/licensing-resources`, and ensures that that page renders properly by adding YAML front-matter to the page. 

I also adjusted the formatting of the headers slightly, since the page title is determined by the front-matter -- and the italicized level 4 header below it has been de-italicized and made into a normal paragraph, to match with the header formatting on [/license-examples](http://project-open-data.github.io/license-examples/). I think this is as it was intended.
