### PR TITLE
Link to merged ToS template

### DIFF
--- a/licensing-resources.md
+++ b/licensing-resources.md
@@ -14,7 +14,7 @@ This is a policy requiring a grant’s recipients to license to the public all n
 
 The policy also requires that the grantees release all software code created with the funds under a license that allows others to use and build upon them and that all grantees must release all new source code developed or created with the grant funds under an open license acceptable to either the Free Software Foundation and/or the Open Source Initiative.
 
-###[Grant Solicitation Language with Open Licensing Requirement](https://www.federalregister.gov/articles/2014/05/16/2014-11463/applications-for-new-awards-first-in-the-world-program-development-grants)   
+###[Grant Solicitation Language with Open Licensing Requirement](https://www.federalregister.gov/articles/2014/05/16/2014-11463/applications-for-new-awards-first-in-the-world-program-development-grants)
 *Department of Education*
 
 Federal Register notice inviting applications and putting applicants on notice that a term and condition of grant awards that contemplate creation or modification of curricular or educational materials will require grantees to grant an open license to the public that enables free use and reuse of all materials with attribution, in order “to ensure that the Federal investment of these funds has as broad an impact as possible.” Source code excepted.
@@ -32,7 +32,7 @@ Commitments that the U.S. Government has made to advance Open Data, and selected
 * [U.S. Open Data Action Plan - High Value Datasets Appendix](http://www.whitehouse.gov/sites/default/files/docs/us_open_data_action_plan_high_value_datasets.csv)
 
 
-###[Model Terms of Service for Open Data APIs](https://github.com/seanherron/API-Resources/blob/revised_draft_tos/developer_tos/vanilla_tos.md)
+###[Model Terms of Service for Open Data APIs](https://github.com/GSA/API-Resources/blob/master/developer_tos/vanilla_tos.md)
 *openFDA*
 
 A model Terms of Service document for APIs (Application Programming Interfaces, which is how systems talk to each other). The model Terms of Service covers several key areas, including limiting agency liability, providing avenues for rate limiting to protect IT resources from abuse, and ensuring that the public domain aspects of data are preserved. The model Terms of Service is currently a work in progress and is available on GitHub in a generic format that any agency can use or contribute to. Extensive feedback and comments have been provided by a number of individuals both inside and outside government, including representatives from GSA, the Sunlight Foundation, and GitHub. A parallel effort, which included review of 24 government APIs, is [documented here](https://groups.google.com/forum/?nomobile=true#!topic/us-government-apis/0yix5bEWbFo)
@@ -54,12 +54,12 @@ Policy that references legal and practical considerations in researching and pro
 
 This Source Code Policy, forked from the DoD/CFPB policy, includes a new "Community Involvement." From the policy:
 
-> **Community involvement**   
-> 18F staff and contractors are encouraged to be active contributors to FOSS projects that 18F or its clients utilize, even if they are not wholly maintained or operated by 18F. 
+> **Community involvement**
+> 18F staff and contractors are encouraged to be active contributors to FOSS projects that 18F or its clients utilize, even if they are not wholly maintained or operated by 18F.
 
-> 18F encourages gratuitous contributions to its open-source projects, whether it be code, commentary, bug reports, feature requests, or overall strategic direction. 
+> 18F encourages gratuitous contributions to its open-source projects, whether it be code, commentary, bug reports, feature requests, or overall strategic direction.
 
-> Because all of 18F’s work is to be released into the public domain, forks or clones of our code repositories are free to be re-distributed into more restrictive licenses, even those that are not considered to be open-source licenses. 
+> Because all of 18F’s work is to be released into the public domain, forks or clones of our code repositories are free to be re-distributed into more restrictive licenses, even those that are not considered to be open-source licenses.
 
 > The public can use our code as the basis of wholly proprietary and commercial systems. 18F would appreciate that users of our code disclose its lineage, but 18F maintains no legal right to require disclosure. Notifications that our work is being used in a new system are always greatly appreciated.
 


### PR DESCRIPTION
Now that @seanherron's ToS got merged in https://github.com/GSA/API-Resources/pull/11, I've updated the link in licensing-resources to point to the merged version.
