### PR TITLE
Re-implement "improve this content button"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,6 @@ branch: master
 #global settings, no need to change these
 root_url: //project-open-data.github.io
 org_name: project-open-data
-prose_url: http://prose.io
 
 # default build settings for running locally, no need to edit
 pymgemnts: true

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="/assets/css/bootstrap.css">
   <link rel="stylesheet" href="/assets/css/site.css">
 
-  {% capture edit_url %}{{ site.prose_url }}#{{ site.org_name }}/{{ site.repo_name }}/edit/{{ site.branch }}/{{ page.filename }}{% endcapture %}
+  {% capture edit_url %}https://github.com/{{ site.org_name }}/{{ site.repo_name }}/edit/{{ site.branch }}/{{ page.filename }}{% endcapture %}
 </head>
 <body class="{{ page.id }}">
   <!--[if lt IE 7]>


### PR DESCRIPTION
Since https://github.com/prose/prose/issues/643 has remained unresolved since early December, this pull request swaps out the Prose-based "Help Improve this content" button, for one that links directly to GitHub's editing interface.

Although admittedly not ideal, I'd argue that a working button that allows the user to complete their designated task is superior to a button that doesn't work but has a more user-friendly interface.
## The flow for authenticated users will now be:
1. Click "improve button"
2. Project will be forked, if not already
3. User makes proposed changes
4. User clicks "propose change"
5. Pull request is created and user is prompted to provide additional details
## The flow for unauthenticated users

User will be asked to login to or signup for GitHub, and then flow will be the same as above.

Fixes #315, /cc @lukefretwell, @leahbannon

_Full Disclosure: I'm a GitHub employee who hates bugs and :heart:'s user-friendly experiences, even for the uninitiated._
