### PR TITLE
Fix edit path for files in folders

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="/assets/css/bootstrap.css">
   <link rel="stylesheet" href="/assets/css/site.css">
 
-  {% capture edit_url %}https://github.com/{{ site.org_name }}/{{ site.repo_name }}/edit/{{ site.branch }}/{{ page.filename }}{% endcapture %}
+  {% capture edit_url %}https://github.com/{{ site.org_name }}/{{ site.repo_name }}/edit/{{ site.branch }}/{{ page.path }}{% endcapture %}
 </head>
 <body class="{{ page.id }}">
   <!--[if lt IE 7]>


### PR DESCRIPTION
The edit link currently breaks for files in folders. If you visit https://project-open-data.cio.gov/v1.1/schema/ and click "Help Improve this Content", it will take you to the editing screen for the top-level `schema.md`, not `v1.1/schema.md`.

This uses `page.path` instead of `page.filename`, which incorporates the full path to that file. It's [documented here](http://jekyllrb.com/docs/variables/#page-variables) and cites formulating edit links as a main use case.
