### PR TITLE
making faq link absolute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ## How to Contribute
 
-This project constitutes a collaborative work ("open source"). Federal employees and members of the public are encouraged to improve the project by contributing. For more information, please see [the FAQ](/faq/)
+This project constitutes a collaborative work ("open source"). Federal employees and members of the public are encouraged to improve the project by contributing. For more information, please see [the FAQ](https://project-open-data.cio.gov/faq/)
 
 Contributions can be made, primarily in two ways:
 


### PR DESCRIPTION
this appears to be necessary since this file is not just used in site but also is automatically linked whenever someone is creating a new issue  and that link goes to the github.com page, where a relative link doesn't work.  

![screen shot 2014-12-08 at 6 30 38 pm](https://cloud.githubusercontent.com/assets/633088/5349606/6ccd3a1e-7f08-11e4-9e75-d48cf4df5eff.png)