### PR TITLE
Fix CDO page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "github-pages"
+gem "jekyll-redirect-from"

--- a/_config.yml
+++ b/_config.yml
@@ -14,3 +14,6 @@ pymgemnts: true
 exclude: ["script", "vendor", "Gemfile", "Gemfile.lock", "config.ru", "Procfile", "Rakefile", "readme.md"]
 markdown: kramdown
 relative_permalinks: false
+
+gems:
+  - jekyll-redirect-from

--- a/chief-data-officers.md
+++ b/chief-data-officers.md
@@ -3,7 +3,7 @@ layout: default
 title: Chief Data Officers
 permalink: /chief-data-officers/
 redirect_from: /chiefdataofficers/
-filename: chiefdataofficers.md
+filename: chief-data-officers.md
 ---
 
 Chief Data Officers

--- a/chiefdataofficers.md
+++ b/chiefdataofficers.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Chief Data Officers
-permalink: /chiefdataofficers/
+permalink: /chief-data-officers/
+redirect_from: /chiefdataofficers/
 filename: chiefdataofficers.md
 ---
 

--- a/chiefdataofficers.md
+++ b/chiefdataofficers.md
@@ -11,25 +11,24 @@ Chief Data Officers
 The Chief Data Officer is an emerging role in US federal government. 
 
 {: .table .table-striped}
-CFO Act Agencies        |  Chief Data Officer                 
---------------          | --------------        
-
-Department of Agriculture     | Bobby Jones, Acting
-Department of Commerce      | Lynn Overmann, Deputy CDO 
-Department of Defense     |
-Department of Education     |
-Department of Energy      | 
-Department of Health and Human Services       |
-Department of Homeland Security     |
+CFO Act Agencies                                |  Chief Data Officer                 
+--------------                                  | --------------        
+Department of Agriculture                       | Bobby Jones, Acting
+Department of Commerce                          | Lynn Overmann, Deputy CDO 
+Department of Defense                           |
+Department of Education                         |
+Department of Energy                            | 
+Department of Health and Human Services         |
+Department of Homeland Security                 |
 Department of Housing and Urban Development     |
-Department of Justice       |
-Department of Labor       |
-Department of State     |
-Department of the Interior      |	 	 	 	 
-Department of the Treasury      |
-Department of Transportation      | Daniel Morgan	 	 	 	 	 
-Department of Veterans Affairs      |
-Environmental Protection Agency       |
-General Services Administration       | Kris Rowley
-National Aeronautics and Space Administration       | 	 	 	 	 
-National Science Foundation     | 
+Department of Justice                           |
+Department of Labor                             |
+Department of State                             |
+Department of the Interior                      |	 	 	 	 
+Department of the Treasury                      |
+Department of Transportation                    | Daniel Morgan	 	 	 	 	 
+Department of Veterans Affairs                  |
+Environmental Protection Agency                 |
+General Services Administration                 | Kris Rowley
+National Aeronautics and Space Administration   | 	 	 	 	 
+National Science Foundation                     | 


### PR DESCRIPTION
Renames the page to chief-data-officers for SEO, readability, consistency, etc. Adds a redirect for previous URL. Also cleans up table formatting. 