### PR TITLE
Changes the license field to Always Required

### DIFF
--- a/v1.1/schema.md
+++ b/v1.1/schema.md
@@ -584,7 +584,7 @@ Dataset Fields {#Dataset}
 **Field [#](#license){: .permalink}** | **license**
 ----- | -----
 **Cardinality** | (0,1)
-**Required** | Yes, if applicable
+**Required** | Yes, always
 **Accepted Values** | String (URL)
 **Usage Notes** | See [list of license-free declarations and licenses](/open-licenses/).
 **Example** |  `{"license":"http://creativecommons.org/publicdomain/zero/1.0/"}`


### PR DESCRIPTION
See the OMB IDC requirements for May 31st: 
> Each agency shall ensure their PDL contains license or non-license (i.e., Public Domain) information for every dataset. Guidance on how to include in the metadadata scheme is provided at https://project-open-data.cio.gov/v1.1/schema/#license, and details on licenses are provided at https://project-open-data.cio.gov/open-licenses/. It’s as simple as adding a URL to your metadata. We highly recommend using the URL for the “Creative Commons 0” license (https://creativecommons.org/publicdomain/zero/1.0/) to indicate that the data is available for unrestricted use in the U.S. and internationally. The White House is working on policy guidance to clarify that all open data in the public domain is by default included in the international public domain.