### PR TITLE
fixing program codes link

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -89,7 +89,7 @@ The following fields must be used to describe each dataset if they are applicabl
 Field                   | Label                 | Definition
 --------------          | --------------        | --------------
 bureauCode				| Bureau Code			| Federal agencies, combined agency and bureau code from [OMB Circular A-11, Appendix C](http://www.whitehouse.gov/sites/default/files/omb/assets/a11_current_year/app_c.pdf) in the format of `015:11`.
-programCode				| Program Code			| Federal agencies, list the primary program related to this data asset, from the [Federal Program Inventory](http://goals.performance.gov/sites/default/files/images/FederalProgramInventory_FY13_MachineReadable_091613.xls). Use the format of `015:001`
+programCode				| Program Code			| Federal agencies, list the primary program related to this data asset, from the [Federal Program Inventory](https://www.performance.gov/sites/default/files/files/FederalProgramInventory_FY13_MachineReadable_091613.xls). Use the format of `015:001`
 accessLevelComment		| Access Level Comment 	| An explanation for the selected “accessLevel” including instructions for how to access a restricted file, if applicable, or explanation for why a “non-public” or “restricted public” data asset is not “public,” if applicable. Text, 255 characters.
 accessURL				| Download URL        	| URL providing direct access to the downloadable distribution of a dataset.
 webService				| Endpoint            	| Endpoint of web service to access dataset.


### PR DESCRIPTION
It's breaking for me right now and [this](https://www.performance.gov/sites/default/files/files/FederalProgramInventory_FY13_MachineReadable_091613.xls) appears to be better.  
