### PR TITLE
Added W3C and IETF to list of data standards bodies

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -20,16 +20,18 @@ For the purposes of implementing of the OMB Memorandum titled “Managing Inform
 System owners and data owners should, wherever possible, consider relevant international and US standards for data elements.  Standards bodies dealing with data include:
 
 #### International Standards
-[ISO](http://www.iso.org/iso/catalogue_ics) 
-[United Nations Centre for Trade Facilitation and Electronic Business (UN/CEFACT)](http://www.unece.org/cefact/about.html)
+* [ISO](http://www.iso.org/iso/catalogue_ics) 
+* [United Nations Centre for Trade Facilitation and Electronic Business (UN/CEFACT)](http://www.unece.org/cefact/about.html)
+* [W3C The World Wide Web Consortium](https://www.w3.org/)
+* [IETF The Internet Engineering Task Force](https://www.ietf.org/)
 
 #### US National Standards
-[American National Standards Institute (ANSI)](http://www.ansi.org/)
-[International Committee for Information Technology Standards (INCITS)](http://incits.org/)
+* [American National Standards Institute (ANSI)](http://www.ansi.org/)
+* [International Committee for Information Technology Standards (INCITS)](http://incits.org/)
 
 #### US Federal Government Standards
-[The Federal Geographic Data Committee (FGDC)](http://www.fgdc.gov/standards)
-[The National Information Exchange Model (NIEM)](https://www.niem.gov/Pages/default.aspx)
+* [The Federal Geographic Data Committee (FGDC)](http://www.fgdc.gov/standards)
+* [The National Information Exchange Model (NIEM)](https://www.niem.gov/Pages/default.aspx)
 
 
 This section of Project Open Data will be updated as guidance evolves.


### PR DESCRIPTION
Hi.
You have a list of standards bodies that purport to meet the definition of voluntary, consensus standards bodies (presumably honoring circular A-199 https://www.whitehouse.gov/omb/circulars_a119) that  also actually provide "convenient, modifiable, and open formats that can be retrieved, downloaded, indexed, and searched" as per your own principles of open data...

Yet you have failed include IETF and W3C which provide the most commonly used open data standards available. Specifically:

IETF -> JSON https://www.ietf.org/rfc/rfc4627.txt
IETF -> CSV https://www.ietf.org/rfc/rfc4180.txt
W3C -> XML https://www.w3.org/XML/
W3C -> HTML https://www.w3.org/html/

Note how I just linked to the open and freely available standards that are easily the four most common formats used to release open data using open standards...

It might also be possible to show the standards bodies that you do recommend leverage JSON and XML. For standards like this one for instance:
http://www.iso.org/iso/catalogue_detail.htm?csnumber=69209

But I cannot do that, because I cannot afford to buy everyone a copy of the license.

I mean. The irony here just writes itself.

Soooo, not sure if this was like a small technical oversite in the website... or more like a massive, colossal lack of backbone by the people running this project... but if its just the former and not the later... here is a github pull request that fixes it.

I also made them bullet lists for readability.. I did not even realize you had a link to ISO until reading this sourcecode...
-FT