### PR TITLE
Purged Linkrot

### DIFF
--- a/policy-memo.md
+++ b/policy-memo.md
@@ -196,17 +196,17 @@ Progress on agency implementation of the actions required in this Memorandum wil
 
 Nothing in this Memorandum shall be construed to affect existing requirements for review and clearance of pre-decisional information by OMB relating to legislative, budgetary, administrative, and regulatory materials. Moreover, nothing in this Memorandum shall be construed to reduce the protection of information whose release would threaten national security, invade personal privacy, breach confidentiality or contractual terms, violate the Trade Secrets Act, [^40] violate other statutory confidentiality requirements, [^41] or damage other compelling interests. This Memorandum is not intended to, and does not, create any right or benefit, substantive or procedural, enforceable at law or in equity by any party against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
 
-[^1]: President Barack Obama, Memorandum on Transparency and Open Government (Jan. 21, 2009), *available at* <a>http://www.whitehouse.gov/the_press_office/TransparencyandOpenGovernment</a>.
+[^1]: President Barack Obama, Memorandum on Transparency and Open Government (Jan. 21, 2009), *available at* <a>http://web.archive.org/web/20170102141539/https://www.whitehouse.gov/the_press_office/TransparencyandOpenGovernment</a>.
 
-[^2]: OMB Memorandum M-10-06, *Open Government Directive* (Dec. 8, 2009), *available at* <a>http://www.whitehouse.gov/sites/default/files/omb/assets/memoranda_2010/m10-06.pdf</a>
+[^2]: OMB Memorandum M-10-06, *Open Government Directive* (Dec. 8, 2009), *available at* <a>https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/memoranda_2010/m10-06.pdf</a>
 
-[^3]: OMB Circular A-130, *available at* <a>http://www.whitehouse.gov/omb/Circulars_a130_a130trans4/</a>
+[^3]: OMB Circular A-130, *available at* <a>https://obamawhitehouse.archives.gov/omb/Circulars_a130_a130trans4/</a>
 
-[^4]: OMB Memorandum M-06-02, *Improving Public Access to and Dissemination of Government Information and Using the Federal Enterprise Architecture Data Reference Model* (Dec. 16, 2005), *available at* <a>http://www.whitehouse.gov/sites/default/files/omb/memoranda/fy2006/m06-02.pdf</a> **
+[^4]: OMB Memorandum M-06-02, *Improving Public Access to and Dissemination of Government Information and Using the Federal Enterprise Architecture Data Reference Model* (Dec. 16, 2005), *available at* <a>https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/fy2006/m06-02.pdf</a> **
 
-[^5]: President Barack Obama, Memorandum on Building a 21st Century Digital Government (May 23, 2012), *available at* <a>http://www.whitehouse.gov/sites/default/files/uploads/2012digital_mem_rel.pdf</a>
+[^5]: President Barack Obama, Memorandum on Building a 21st Century Digital Government (May 23, 2012), *available at* <a>https://obamawhitehouse.archives.gov/sites/default/files/uploads/2012digital_mem_rel.pdf</a>
 
-[^6]: Office of Management and Budget, *Digital Government: Building a 21<sup>st</sup> Century Platform to Better Serve the American People* (May 23, 2012), *available at* <a>http://www.whitehouse.gov/sites/default/files/omb/egov/digital-government/digital-government-strategy.pdf</a>
+[^6]: Office of Management and Budget, *Digital Government: Building a 21<sup>st</sup> Century Platform to Better Serve the American People* (May 23, 2012), *available at* <a>https://obamawhitehouse.archives.gov/sites/default/files/omb/egov/digital-government/digital-government-strategy.pdf</a>
 
 [^7]: 44 U.S.C. § 3501 *et seq.*
 
@@ -216,39 +216,39 @@ Nothing in this Memorandum shall be construed to affect existing requirements fo
 
 [^10]: 44 U.S.C. § 3541, *et seq*.
 
-[^11]: Section 503(a), Pub. L. No. 107-347, 116 Stat. 2899 (2002) (codified as 44 U.S.C. § 3501 note); *see also* Implementation Guidance for Title V of the E-Government Act, Confidential Information Protection and Statistical Efficiency Act of 2002 (CIPSEA), *available at* <a>http://www.whitehouse.gov/sites/default/files/omb/assets/omb/fedreg/2007/061507_cipsea_guidance.pdf</a>
+[^11]: Section 503(a), Pub. L. No. 107-347, 116 Stat. 2899 (2002) (codified as 44 U.S.C. § 3501 note); *see also* Implementation Guidance for Title V of the E-Government Act, Confidential Information Protection and Statistical Efficiency Act of 2002 (CIPSEA), *available at* <a>https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/omb/fedreg/2007/061507_cipsea_guidance.pdf</a>
 
 [^12]: 5 USC 552(a)(2).
 
-[^13]: Pub. L. No. 106-554 (2000) (codified at 44 U.S.C. § 3504(d)(1) and 3516). *See also* OMB Memorandum M-12-18, *Managing Government Records Directive* (Aug. 24, 2012), *available at* <a>http://www.whitehouse.gov/sites/default/files/omb/memoranda/2012/m-12-18.pdf</a>.
+[^13]: Pub. L. No. 106-554 (2000) (codified at 44 U.S.C. § 3504(d)(1) and 3516). *See also* OMB Memorandum M-12-18, *Managing Government Records Directive* (Aug. 24, 2012), *available at* <a>https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2012/m-12-18.pdf</a>.
 
 [^14]: 44 U.S.C. Chapters 21, 22, 29, 31, and 33. *See also* 36 CFR Subchapter B &#8211; Records Management.
 
 [^15]: *Structured* information is to be contrasted with *unstructured* information (commonly referred to as "content") such as press releases and fact sheets. As described in the *Digital Government Strategy*, content may be converted to a structured format and treated as data. For example, a web-based fact sheet may be broken into the following component data pieces: the title, body text, images, and related links.
 
-[^16]: The White House, *National Strategy for Trusted Identities in Cyberspace* (April 2011), *available at* <a>http://www.whitehouse.gov/sites/default/files/rss_viewer/NSTICstrategy_041511.pdf</a>
+[^16]: The White House, *National Strategy for Trusted Identities in Cyberspace* (April 2011), *available at* <a>https://obamawhitehouse.archives.gov/sites/default/files/rss_viewer/NSTICstrategy_041511.pdf</a>
 
-[^17]: OMB Memorandum M-10-23, *Guidance for Agency Use of Third-Party Websites and Applications* (June 25, 2010), *available at* <a>http://www.whitehouse.gov/sites/default/files/omb/assets/memoranda_2010/m10-23.pdf</a>
+[^17]: OMB Memorandum M-10-23, *Guidance for Agency Use of Third-Party Websites and Applications* (June 25, 2010), *available at* <a>https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/memoranda_2010/m10-23.pdf</a>
 
 [^18]: Links to the best practices developed in Project Open Data referenced in this memorandum can be found through the directory on this main page.
 
-[^19]: The requirements of this subsection build upon existing requirements in OMB Statistical Policy Directives No. 1 and No. 2, *available at* <a>http://www.whitehouse.gov/sites/default/files/omb/assets/omb/inforeg/directive1.pdf</a> and <a>http://www.whitehouse.gov/sites/default/files/omb/assets/omb/inforeg/directive2.pdf</a>.
+[^19]: The requirements of this subsection build upon existing requirements in OMB Statistical Policy Directives No. 1 and No. 2, *available at* <a>https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/omb/inforeg/directive1.pdf</a> and <a>https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/omb/inforeg/directive2.pdf</a>.
 
-[^20]: *See* OMB Circular A-119, *available at* <a>http://www.whitehouse.gov/omb/circulars_a119</a>, and OMB Memorandum M-12-08, *Principles for Federal Engagement in Standards Activities to Address National Priorities* (Jan 27, 2012), *available at* <a>http://www.whitehouse.gov/sites/default/files/omb/memoranda/2012/m-12-08.pdf</a>
+[^20]: *See* OMB Circular A-119, *available at* <a>https://obamawhitehouse.archives.gov/omb/circulars_a119</a>, and OMB Memorandum M-12-08, *Principles for Federal Engagement in Standards Activities to Address National Priorities* (Jan 27, 2012), *available at* <a>https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2012/m-12-08.pdf</a>
 
 [^21]: If a data user augments or alters original information that is attributed to the Federal Government, the user is responsible for making clear the source and nature of that augmentation.
 
-[^22]: *See* Federal Acquisition Regulation (FAR) Subpart 27.4&#8212;Rights in Data and Copyrights, *available at* <a>https://acquisition.gov/far/current/html/Subpart%2027_4.html</a>
+[^22]: *See* Federal Acquisition Regulation (FAR) Subpart 27.4&#8212;Rights in Data and Copyrights, *available at* <a>http://web.archive.org/web/20170118203324/https://www.acquisition.gov/far/current/html/Subpart%2027_4.html</a>
 
-[^23]: Office of Management and Budget, Common Approach to Federal Enterprise Architecture, *available at* http://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/common_approach_to_federal_ea.pdf
+[^23]: Office of Management and Budget, Common Approach to Federal Enterprise Architecture, *available at* https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/egov_docs/common_approach_to_federal_ea.pdf
 
 [^24]: *See* OMB Circular A-130, section 8(b)(2)(a).
 
-[^25]: Office of Management and Budget, Federal Enterprise Architecture (FEA) Reference Models, *available at* <a>http://www.whitehouse.gov/omb/e-gov/fea</a>
+[^25]: Office of Management and Budget, Federal Enterprise Architecture (FEA) Reference Models, *available at* <a>https://obamawhitehouse.archives.gov/omb/e-gov/fea</a>
 
-[^26]: OMB Statistical Policy Directives 3 and 4 describe the schedule and manner in which data produced by the principal statistical agencies will be released. Statistical Policy Directive No. 4: Release and Dissemination of Statistical Products Produced by Federal Statistical Agencies, *available at* <a>http://www.whitehouse.gov/sites/default/files/omb/assets/omb/fedreg/2008/030708_directive-4.pdf</a>; Statistical Policy Directive 3: Compilation, Release, and Evaluation of Principal Federal Economic Indicators, *available at* <a>http://www.whitehouse.gov/sites/default/files/omb/assets/omb/inforeg/statpolicy/dir_3_fr_09251985.pdf</a>
+[^26]: OMB Statistical Policy Directives 3 and 4 describe the schedule and manner in which data produced by the principal statistical agencies will be released. Statistical Policy Directive No. 4: Release and Dissemination of Statistical Products Produced by Federal Statistical Agencies, *available at* <a>https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/omb/fedreg/2008/030708_directive-4.pdf</a>; Statistical Policy Directive 3: Compilation, Release, and Evaluation of Principal Federal Economic Indicators, *available at* <a>https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/omb/inforeg/statpolicy/dir_3_fr_09251985.pdf</a>
 
-[^27]: *See* OMB Circular A-130, *available at* <a>http://www.whitehouse.gov/omb/Circulars_a130_a130trans4/</a>
+[^27]: *See* OMB Circular A-130, *available at* <a>https://obamawhitehouse.archives.gov/omb/Circulars_a130_a130trans4/</a>
 
 [^28]: NIST FIPS Publication 199 "Standards for Security Categorization of Federal Information and Information Systems", *available at*  <a>http://csrc.nist.gov/publications/fips/fips199/FIPS-PUB-199-final.pdf</a>
 


### PR DESCRIPTION
fixed all the broken links. got all but one from whitehouse.gov to point to obamawhitehouse.gov, fixed that via wayback machine. 
acquisitions.gov is down, so used wayback there as well.
csrc.nist.gov is still up, but i did save it in the wayback just for safe keeping.