### PR TITLE
USG Open Data Quarterly + Biweekly fixes

### DIFF
--- a/workinggroup.md
+++ b/workinggroup.md
@@ -9,7 +9,18 @@ filename: working-group.md
 
 Anyone with a .gov or .mil email address can join by emailing listserv@listserv.gsa.gov, the message should have no subject and the body should say “subscribe open-data”.
 
-## Attend Weekly Implementation Support Meetings
+Subscribe to the public mailing list: https://groups.google.com/forum/#!topic/opengovtech/dnyjc6-v41Q
 
-Weekly Implementation support meetings are held every Tuesday at GSA. To receive the most recent meeting information, join the listserv.
+## Attend Biweekly Implementation Support Meetings
 
+Biweekly Implementation support meetings are held every Tuesday at GSA for Federal employees and contractors. To receive the most recent meeting information, join the OPEN-DATA listserv managed by GSA.
+
+U.S. Governemnt Open Data meetings are open to the public on a quarterly basis. To receive invitations and join the community, subscribe to the public mailing list.
+
+## Open Data – Data.gov
+
+Responsibly unleash the power of data for the benefit of the American public and maximize the Nation’s return on its investment in data. Data is an asset to be leveraged and strengthen our democracy, promote government efficiencies, and improve citizens’ quality of life when it is made available, discoverable, and usable to the public – in a word, “open”. 
+
+## Questions?
+
+Email datagov@gsa.gov 


### PR DESCRIPTION
Adding in the USG Open Data quarterly listserv info, which GSA & others have already created. Updated meeting info to reflect biweekly (not weekly). Added some context -- overview mission & purpose of group, consistent with other GSA managed listserves.