### PR TITLE
remove dead link to goals.performance.gov

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -62,7 +62,6 @@
               <li><a href="/policy-memo">Policy - OMB M-13-13</a></li>
               <li><a href="/implementation-guide">Implementation Guide</a></li>
               <li><a href="/catalog">Public Data Listing</a></li>
-              <li><a href="http://goals.performance.gov/opendata">Open Data CAP Goal</a></li>
               <li><a href="/faq">FAQ</a></li>
             </ul>
           </li>


### PR DESCRIPTION
The link to goals.performance.gov no longer works so I have a PR to remove it.

If goals.performance.gov has moved then you can treat this PR as an issue to update it to the current location.