### PR TITLE
Use vcard:hasEmail instead of the deprecated vcard:email

### DIFF
--- a/v1.1/schema/catalog.jsonld
+++ b/v1.1/schema/catalog.jsonld
@@ -51,7 +51,7 @@
     "primaryITInvestmentUII": "pod:primaryITInvestmentUII",
     "programCode": "pod:programCode",
     "fn": "vcard:fn",
-    "hasEmail": "vcard:email",
+    "hasEmail": "vcard:hasEmail",
     "name": "skos:prefLabel",
     "subOrganizationOf": "org:subOrganizationOf"
   }


### PR DESCRIPTION
`vcard:email` has been deprecated for quite a while in favour of `vcard:hasEmail` (which is actually mentioned elsewhere in the schema documentation)